### PR TITLE
[#10] Dropdown에 top, bottom, left, right direction 설정 기능 추가

### DIFF
--- a/src/components/dropdown/index.tsx
+++ b/src/components/dropdown/index.tsx
@@ -34,53 +34,25 @@ function layoutStyles({
   alignment: Alignment;
   alignmentOffset: number;
 }) {
-  const styles: Edge = {};
+  const directionValue = `calc(100% + ${gap}px)`;
+  const directionStyles: Record<Direction, Edge> = {
+    top: { bottom: directionValue },
+    bottom: { top: directionValue },
+    left: { right: directionValue },
+    right: { left: directionValue },
+  };
 
-  switch (direction) {
-    case "top":
-      styles.bottom = `calc(100% + ${gap}px)`;
-      break;
-    case "bottom":
-      styles.top = `calc(100% + ${gap}px)`;
-      break;
-    case "left":
-      styles.right = `calc(100% + ${gap}px)`;
-      break;
-    case "right":
-      styles.left = `calc(100% + ${gap}px)`;
-      break;
-  }
+  const isHorizontalDirection = direction === "left" || direction === "right";
+  const isVerticalDirection = direction === "top" || direction === "bottom";
+  const alignmentStyles: Record<Alignment, Edge> = {
+    top: isHorizontalDirection ? { top: alignmentOffset } : {},
+    bottom: isHorizontalDirection ? { bottom: alignmentOffset } : {},
+    left: isVerticalDirection ? { left: alignmentOffset } : {},
+    right: isVerticalDirection ? { right: alignmentOffset } : {},
+    fill: isVerticalDirection ? { left: 0, right: 0 } : {},
+  };
 
-  switch (alignment) {
-    case "top":
-      if (direction === "left" || direction === "right") {
-        styles.top = alignmentOffset;
-      }
-      break;
-    case "bottom":
-      if (direction === "left" || direction === "right") {
-        styles.bottom = alignmentOffset;
-      }
-      break;
-    case "left":
-      if (direction === "top" || direction === "bottom") {
-        styles.left = alignmentOffset;
-      }
-      break;
-    case "right":
-      if (direction === "top" || direction === "bottom") {
-        styles.right = alignmentOffset;
-      }
-      break;
-    case "fill":
-      if (direction === "top" || direction === "bottom") {
-        styles.left = 0;
-        styles.right = 0;
-      }
-      break;
-  }
-
-  return styles;
+  return { ...directionStyles[direction], ...alignmentStyles[alignment] };
 }
 
 export default function Dropdown({

--- a/src/components/dropdown/index.tsx
+++ b/src/components/dropdown/index.tsx
@@ -2,9 +2,9 @@ import { useBackdropClick } from "@/hooks/use-backdrop-click";
 import clsx from "clsx";
 import { CSSProperties, ReactNode, useState } from "react";
 
-type Alignment = "left" | "right" | "fill";
+type Alignment = "top" | "bottom" | "left" | "right" | "fill";
 
-type Direction = "top" | "bottom";
+type Direction = "top" | "bottom" | "left" | "right";
 
 export interface DropdownOption {
   label: string;
@@ -21,6 +21,8 @@ interface Props {
   onSelect: (option: DropdownOption | string) => void;
 }
 
+type Edge = Pick<CSSProperties, "top" | "left" | "right" | "bottom">;
+
 function layoutStyles({
   gap,
   direction,
@@ -32,7 +34,7 @@ function layoutStyles({
   alignment: Alignment;
   alignmentOffset: number;
 }) {
-  const styles: Pick<CSSProperties, "top" | "left" | "right" | "bottom"> = {};
+  const styles: Edge = {};
 
   switch (direction) {
     case "top":
@@ -41,17 +43,40 @@ function layoutStyles({
     case "bottom":
       styles.top = `calc(100% + ${gap}px)`;
       break;
-  }
-  switch (alignment) {
     case "left":
-      styles.left = alignmentOffset;
+      styles.right = `calc(100% + ${gap}px)`;
       break;
     case "right":
-      styles.right = alignmentOffset;
+      styles.left = `calc(100% + ${gap}px)`;
+      break;
+  }
+
+  switch (alignment) {
+    case "top":
+      if (direction === "left" || direction === "right") {
+        styles.top = alignmentOffset;
+      }
+      break;
+    case "bottom":
+      if (direction === "left" || direction === "right") {
+        styles.bottom = alignmentOffset;
+      }
+      break;
+    case "left":
+      if (direction === "top" || direction === "bottom") {
+        styles.left = alignmentOffset;
+      }
+      break;
+    case "right":
+      if (direction === "top" || direction === "bottom") {
+        styles.right = alignmentOffset;
+      }
       break;
     case "fill":
-      styles.left = 0;
-      styles.right = 0;
+      if (direction === "top" || direction === "bottom") {
+        styles.left = 0;
+        styles.right = 0;
+      }
       break;
   }
 

--- a/src/components/dropdown/index.tsx
+++ b/src/components/dropdown/index.tsx
@@ -1,8 +1,10 @@
 import { useBackdropClick } from "@/hooks/use-backdrop-click";
 import clsx from "clsx";
-import { ReactNode, useState } from "react";
+import { CSSProperties, ReactNode, useState } from "react";
 
 type Alignment = "left" | "right" | "fill";
+
+type Direction = "top" | "bottom";
 
 export interface DropdownOption {
   label: string;
@@ -13,15 +15,54 @@ interface Props {
   anchor: ReactNode;
   options: DropdownOption[] | string[];
   gap?: number;
+  direction?: Direction;
   alignment?: Alignment;
   alignmentOffset?: number;
   onSelect: (option: DropdownOption | string) => void;
+}
+
+function layoutStyles({
+  gap,
+  direction,
+  alignment,
+  alignmentOffset,
+}: {
+  gap: number;
+  direction: Direction;
+  alignment: Alignment;
+  alignmentOffset: number;
+}) {
+  const styles: Pick<CSSProperties, "top" | "left" | "right" | "bottom"> = {};
+
+  switch (direction) {
+    case "top":
+      styles.bottom = `calc(100% + ${gap}px)`;
+      break;
+    case "bottom":
+      styles.top = `calc(100% + ${gap}px)`;
+      break;
+  }
+  switch (alignment) {
+    case "left":
+      styles.left = alignmentOffset;
+      break;
+    case "right":
+      styles.right = alignmentOffset;
+      break;
+    case "fill":
+      styles.left = 0;
+      styles.right = 0;
+      break;
+  }
+
+  return styles;
 }
 
 export default function Dropdown({
   anchor,
   options,
   gap = 8,
+  direction = "bottom",
   alignment = "left",
   alignmentOffset = 0,
   onSelect,
@@ -30,19 +71,6 @@ export default function Dropdown({
   const targetRef = useBackdropClick<HTMLDivElement>({
     callback: () => setIsOpen(false),
   });
-
-  const alignmentStyles = { top: `calc(100% + ${gap}px)` };
-  switch (alignment) {
-    case "left":
-      Object.assign(alignmentStyles, { left: alignmentOffset });
-      break;
-    case "right":
-      Object.assign(alignmentStyles, { right: alignmentOffset });
-      break;
-    case "fill":
-      Object.assign(alignmentStyles, { left: 0, right: 0 });
-      break;
-  }
 
   const handleAnchorClick = () => {
     setIsOpen(!isOpen);
@@ -65,7 +93,7 @@ export default function Dropdown({
             "bg-background-primary",
             "z-(--z-overlay)"
           )}
-          style={alignmentStyles}
+          style={layoutStyles({ gap, direction, alignment, alignmentOffset })}
         >
           {options.map((option) => {
             const key = typeof option === "string" ? option : option.value;

--- a/src/stories/Dropdown.stories.tsx
+++ b/src/stories/Dropdown.stories.tsx
@@ -14,37 +14,81 @@ export default meta;
 
 export function Dropdown() {
   return (
-    <div className="flex flex-col gap-4">
-      <DropdownComponent
-        anchor={<Button title="Align Left" isFullWidth={false} />}
-        options={["Option 1", "Option 2", "Option 3"]}
-        onSelect={(option) => console.log(option)}
-      />
-      <DropdownComponent
-        anchor={<Button title="Align Right" isFullWidth={false} />}
-        options={[
-          { value: "option-1", label: "Option 1" },
-          { value: "option-2", label: "Option 2" },
-          { value: "option-3", label: "Option 3" },
-        ]}
-        alignment="right"
-        onSelect={(option) => console.log(option)}
-      />
-      <DropdownComponent
-        anchor={
-          <Button title="Align fill with long anchor" isFullWidth={false} />
-        }
-        options={["Option 1", "Option 2", "Option 3"]}
-        alignment="fill"
-        onSelect={(option) => console.log(option)}
-      />
-      <DropdownComponent
-        anchor={<Button title="Align offset" isFullWidth={false} />}
-        options={["Option 1", "Option 2", "Option 3"]}
-        alignment="right"
-        alignmentOffset={-24}
-        onSelect={(option) => console.log(option)}
-      />
+    <div className="flex gap-12">
+      <div className="flex flex-col gap-4">
+        <DropdownComponent
+          anchor={<Button title="Top Left" isFullWidth={false} />}
+          options={["Option 1", "Option 2", "Option 3"]}
+          direction="top"
+          alignment="left"
+          onSelect={(option) => console.log(option)}
+        />
+        <DropdownComponent
+          anchor={<Button title="Top Right" isFullWidth={false} />}
+          options={[
+            { value: "option-1", label: "Option 1" },
+            { value: "option-2", label: "Option 2" },
+            { value: "option-3", label: "Option 3" },
+          ]}
+          direction="top"
+          alignment="right"
+          onSelect={(option) => console.log(option)}
+        />
+        <DropdownComponent
+          anchor={
+            <Button title="Top fill with long anchor" isFullWidth={false} />
+          }
+          options={["Option 1", "Option 2", "Option 3"]}
+          direction="top"
+          alignment="fill"
+          onSelect={(option) => console.log(option)}
+        />
+        <DropdownComponent
+          anchor={<Button title="Top offset" isFullWidth={false} />}
+          options={["Option 1", "Option 2", "Option 3"]}
+          direction="top"
+          alignment="right"
+          alignmentOffset={-24}
+          onSelect={(option) => console.log(option)}
+        />
+      </div>
+      <div className="flex flex-col gap-4">
+        <DropdownComponent
+          anchor={<Button title="Bottom Left" isFullWidth={false} />}
+          options={["Option 1", "Option 2", "Option 3"]}
+          direction="bottom"
+          alignment="left"
+          onSelect={(option) => console.log(option)}
+        />
+        <DropdownComponent
+          anchor={<Button title="Bottom Right" isFullWidth={false} />}
+          options={[
+            { value: "option-1", label: "Option 1" },
+            { value: "option-2", label: "Option 2" },
+            { value: "option-3", label: "Option 3" },
+          ]}
+          direction="bottom"
+          alignment="right"
+          onSelect={(option) => console.log(option)}
+        />
+        <DropdownComponent
+          anchor={
+            <Button title="Bottom fill with long anchor" isFullWidth={false} />
+          }
+          options={["Option 1", "Option 2", "Option 3"]}
+          direction="bottom"
+          alignment="fill"
+          onSelect={(option) => console.log(option)}
+        />
+        <DropdownComponent
+          anchor={<Button title="Bottom offset" isFullWidth={false} />}
+          options={["Option 1", "Option 2", "Option 3"]}
+          direction="bottom"
+          alignment="right"
+          alignmentOffset={-24}
+          onSelect={(option) => console.log(option)}
+        />
+      </div>
     </div>
   );
 }

--- a/src/stories/Dropdown.stories.tsx
+++ b/src/stories/Dropdown.stories.tsx
@@ -12,83 +12,184 @@ const meta = {
 
 export default meta;
 
-export function Dropdown() {
+export function DropdownOnTop() {
   return (
-    <div className="flex gap-12">
-      <div className="flex flex-col gap-4">
-        <DropdownComponent
-          anchor={<Button title="Top Left" isFullWidth={false} />}
-          options={["Option 1", "Option 2", "Option 3"]}
-          direction="top"
-          alignment="left"
-          onSelect={(option) => console.log(option)}
-        />
-        <DropdownComponent
-          anchor={<Button title="Top Right" isFullWidth={false} />}
-          options={[
-            { value: "option-1", label: "Option 1" },
-            { value: "option-2", label: "Option 2" },
-            { value: "option-3", label: "Option 3" },
-          ]}
-          direction="top"
-          alignment="right"
-          onSelect={(option) => console.log(option)}
-        />
-        <DropdownComponent
-          anchor={
-            <Button title="Top fill with long anchor" isFullWidth={false} />
-          }
-          options={["Option 1", "Option 2", "Option 3"]}
-          direction="top"
-          alignment="fill"
-          onSelect={(option) => console.log(option)}
-        />
-        <DropdownComponent
-          anchor={<Button title="Top offset" isFullWidth={false} />}
-          options={["Option 1", "Option 2", "Option 3"]}
-          direction="top"
-          alignment="right"
-          alignmentOffset={-24}
-          onSelect={(option) => console.log(option)}
-        />
-      </div>
-      <div className="flex flex-col gap-4">
-        <DropdownComponent
-          anchor={<Button title="Bottom Left" isFullWidth={false} />}
-          options={["Option 1", "Option 2", "Option 3"]}
-          direction="bottom"
-          alignment="left"
-          onSelect={(option) => console.log(option)}
-        />
-        <DropdownComponent
-          anchor={<Button title="Bottom Right" isFullWidth={false} />}
-          options={[
-            { value: "option-1", label: "Option 1" },
-            { value: "option-2", label: "Option 2" },
-            { value: "option-3", label: "Option 3" },
-          ]}
-          direction="bottom"
-          alignment="right"
-          onSelect={(option) => console.log(option)}
-        />
-        <DropdownComponent
-          anchor={
-            <Button title="Bottom fill with long anchor" isFullWidth={false} />
-          }
-          options={["Option 1", "Option 2", "Option 3"]}
-          direction="bottom"
-          alignment="fill"
-          onSelect={(option) => console.log(option)}
-        />
-        <DropdownComponent
-          anchor={<Button title="Bottom offset" isFullWidth={false} />}
-          options={["Option 1", "Option 2", "Option 3"]}
-          direction="bottom"
-          alignment="right"
-          alignmentOffset={-24}
-          onSelect={(option) => console.log(option)}
-        />
-      </div>
+    <div className="flex flex-col gap-4">
+      <DropdownComponent
+        anchor={<Button title="Top Left" isFullWidth={false} />}
+        options={["Option 1", "Option 2", "Option 3"]}
+        direction="top"
+        alignment="left"
+        onSelect={(option) => console.log(option)}
+      />
+      <DropdownComponent
+        anchor={<Button title="Top Right" isFullWidth={false} />}
+        options={[
+          { value: "option-1", label: "Option 1" },
+          { value: "option-2", label: "Option 2" },
+          { value: "option-3", label: "Option 3" },
+        ]}
+        direction="top"
+        alignment="right"
+        onSelect={(option) => console.log(option)}
+      />
+      <DropdownComponent
+        anchor={
+          <Button title="Top fill with long anchor" isFullWidth={false} />
+        }
+        options={["Option 1", "Option 2", "Option 3"]}
+        direction="top"
+        alignment="fill"
+        onSelect={(option) => console.log(option)}
+      />
+      <DropdownComponent
+        anchor={<Button title="Top offset" isFullWidth={false} />}
+        options={["Option 1", "Option 2", "Option 3"]}
+        direction="top"
+        alignment="right"
+        alignmentOffset={-24}
+        onSelect={(option) => console.log(option)}
+      />
+    </div>
+  );
+}
+
+export function DropdownOnBottom() {
+  return (
+    <div className="flex flex-col gap-4">
+      <DropdownComponent
+        anchor={<Button title="Bottom Left" isFullWidth={false} />}
+        options={["Option 1", "Option 2", "Option 3"]}
+        direction="bottom"
+        alignment="left"
+        onSelect={(option) => console.log(option)}
+      />
+      <DropdownComponent
+        anchor={<Button title="Bottom Right" isFullWidth={false} />}
+        options={[
+          { value: "option-1", label: "Option 1" },
+          { value: "option-2", label: "Option 2" },
+          { value: "option-3", label: "Option 3" },
+        ]}
+        direction="bottom"
+        alignment="right"
+        onSelect={(option) => console.log(option)}
+      />
+      <DropdownComponent
+        anchor={
+          <Button title="Bottom fill with long anchor" isFullWidth={false} />
+        }
+        options={["Option 1", "Option 2", "Option 3"]}
+        direction="bottom"
+        alignment="fill"
+        onSelect={(option) => console.log(option)}
+      />
+      <DropdownComponent
+        anchor={<Button title="Bottom offset" isFullWidth={false} />}
+        options={["Option 1", "Option 2", "Option 3"]}
+        direction="bottom"
+        alignment="right"
+        alignmentOffset={-24}
+        onSelect={(option) => console.log(option)}
+      />
+    </div>
+  );
+}
+
+export function DropdownOnLeft() {
+  return (
+    <div className="flex flex-col gap-4">
+      <DropdownComponent
+        anchor={<Button title="Left Top" isFullWidth={false} />}
+        options={["Option 1", "Option 2", "Option 3"]}
+        direction="left"
+        alignment="top"
+        onSelect={(option) => console.log(option)}
+      />
+      <DropdownComponent
+        anchor={<Button title="Left Bottom" isFullWidth={false} />}
+        options={[
+          { value: "option-1", label: "Option 1" },
+          { value: "option-2", label: "Option 2" },
+          { value: "option-3", label: "Option 3" },
+        ]}
+        direction="left"
+        alignment="bottom"
+        onSelect={(option) => console.log(option)}
+      />
+      <DropdownComponent
+        anchor={<Button title="Left Top Offset" isFullWidth={false} />}
+        options={[
+          { value: "option-1", label: "Option 1" },
+          { value: "option-2", label: "Option 2" },
+          { value: "option-3", label: "Option 3" },
+        ]}
+        direction="left"
+        alignment="top"
+        alignmentOffset={-24}
+        onSelect={(option) => console.log(option)}
+      />
+      <DropdownComponent
+        anchor={<Button title="Left Bottom Offset" isFullWidth={false} />}
+        options={[
+          { value: "option-1", label: "Option 1" },
+          { value: "option-2", label: "Option 2" },
+          { value: "option-3", label: "Option 3" },
+        ]}
+        direction="left"
+        alignment="bottom"
+        alignmentOffset={-24}
+        onSelect={(option) => console.log(option)}
+      />
+    </div>
+  );
+}
+
+export function DropdownOnRight() {
+  return (
+    <div className="flex flex-col gap-4">
+      <DropdownComponent
+        anchor={<Button title="Right Top" isFullWidth={false} />}
+        options={["Option 1", "Option 2", "Option 3"]}
+        direction="right"
+        alignment="top"
+        onSelect={(option) => console.log(option)}
+      />
+      <DropdownComponent
+        anchor={<Button title="Right Bottom" isFullWidth={false} />}
+        options={[
+          { value: "option-1", label: "Option 1" },
+          { value: "option-2", label: "Option 2" },
+          { value: "option-3", label: "Option 3" },
+        ]}
+        direction="right"
+        alignment="bottom"
+        onSelect={(option) => console.log(option)}
+      />
+      <DropdownComponent
+        anchor={<Button title="Right Top Offset" isFullWidth={false} />}
+        options={[
+          { value: "option-1", label: "Option 1" },
+          { value: "option-2", label: "Option 2" },
+          { value: "option-3", label: "Option 3" },
+        ]}
+        direction="right"
+        alignment="top"
+        alignmentOffset={-24}
+        onSelect={(option) => console.log(option)}
+      />
+      <DropdownComponent
+        anchor={<Button title="Right Bottom Offset" isFullWidth={false} />}
+        options={[
+          { value: "option-1", label: "Option 1" },
+          { value: "option-2", label: "Option 2" },
+          { value: "option-3", label: "Option 3" },
+        ]}
+        direction="right"
+        alignment="bottom"
+        alignmentOffset={-24}
+        onSelect={(option) => console.log(option)}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## 📝 요약

- `Dropdown`을 anchor의 상/하/좌/우로 펼치는 기능을 추가합니다.

## ✨ 구현 내용

- `direction` prop을 통해 dropdown이 anchor 기준 펼쳐지는 위치를 설정할 수 있도록 구현합니다.

### 🎯 실제 결과

| Top | Bottom | Left | Right |
|--------|--------|--------|--------|
| <img width="422" height="432" alt="image" src="https://github.com/user-attachments/assets/d83dfb15-b8c6-4f1b-81c7-dd53c2cbb49b" /> | <img width="422" height="432" alt="image" src="https://github.com/user-attachments/assets/232d9a46-d1d1-4a2f-b84c-20dafc726ebf" /> | <img width="422" height="432" alt="image" src="https://github.com/user-attachments/assets/b892033a-540c-4742-8c04-efba0d6ee327" /> | <img width="422" height="432" alt="image" src="https://github.com/user-attachments/assets/e3f98496-919a-4c80-8064-f5e664253888" /> | 

---

## 💬 리뷰어 참고 사항 및 알게된 점

- 이 수정사항을 바탕으로 `Sidebar`에서 프로필을 클릭했을 때 메뉴가 표시되도록 구현할 예정입니다.

## ✅ 체크리스트

- [x] 주요 기능 테스트 완료
- [x] 빌드 및 실행 확인
- [x] 커밋 메시지 컨벤션 및 작업 내용 일치 확인