### PR TITLE
[#9] Sidebar 개발 (2)

### DIFF
--- a/src/components/gnb/ProfileMenu.tsx
+++ b/src/components/gnb/ProfileMenu.tsx
@@ -1,0 +1,31 @@
+import { ReactNode } from "react";
+import Dropdown, { DropdownOption } from "../dropdown";
+
+interface Props {
+  anchor: ReactNode;
+}
+
+export default function ProfileMenu({ anchor }: Props) {
+  const options: DropdownOption[] = [
+    { label: "마이 히스토리", value: "myhistory" },
+    { label: "계정 설정", value: "mypage" },
+    { label: "팀 참여", value: "joinTeam" },
+    { label: "로그아웃", value: "logout" },
+  ];
+
+  const handleSelect = (option: DropdownOption) => {
+    console.log("Selected option:", option);
+  };
+
+  return (
+    <Dropdown
+      anchor={anchor}
+      options={options}
+      gap={16}
+      direction="right"
+      alignment="bottom"
+      alignmentOffset={16}
+      onSelect={(option) => handleSelect(option as DropdownOption)}
+    />
+  );
+}

--- a/src/components/gnb/Sidebar.tsx
+++ b/src/components/gnb/Sidebar.tsx
@@ -2,12 +2,13 @@ import LogoFull from "@/assets/images/logo-full.svg";
 import Logo from "@/assets/images/logo.svg";
 import Icon from "@/components/icon";
 import { getUserGroups } from "@/features/group/apis";
+import { useSidebarStore } from "@/stores/sidebar-store";
 import { useQuery } from "@tanstack/react-query";
 import clsx from "clsx";
 import { motion } from "motion/react";
 import Link from "next/link";
 import { useRouter } from "next/router";
-import { useState } from "react";
+import { useShallow } from "zustand/shallow";
 import Avatar from "../avatar";
 import { Button } from "../button";
 import SidebarMenu from "./SidebarMenu";
@@ -22,10 +23,12 @@ function sidebarWidthClassName(isFolded: boolean) {
 }
 
 export default function Sidebar() {
-  const [isFolded, setIsFolded] = useState(false);
+  const [isFolded, setIsFolded] = useSidebarStore(
+    useShallow((state) => [state.isFold, state.toggle])
+  );
 
   const handleFoldClick = () => {
-    setIsFolded(!isFolded);
+    setIsFolded();
   };
 
   return (

--- a/src/components/gnb/Sidebar.tsx
+++ b/src/components/gnb/Sidebar.tsx
@@ -22,7 +22,11 @@ function sidebarWidthClassName(isFolded: boolean) {
   return isFolded ? `w-[72px]` : `w-[270px]`;
 }
 
-export default function Sidebar() {
+interface Props {
+  className?: string;
+}
+
+export default function Sidebar({ className }: Props) {
   const [isFolded, setIsFolded] = useSidebarStore(
     useShallow((state) => [state.isFold, state.toggle])
   );
@@ -35,7 +39,8 @@ export default function Sidebar() {
     <motion.nav
       className={clsx(
         "flex h-dvh shrink-0 flex-col border-r border-border-primary bg-background-primary text-text-primary",
-        sidebarWidthClassName(isFolded)
+        sidebarWidthClassName(isFolded),
+        className
       )}
       animate={{ width: sidebarWidth(isFolded) }}
       transition={{ ease: "easeInOut", duration: 0.1 }}

--- a/src/components/gnb/Sidebar.tsx
+++ b/src/components/gnb/Sidebar.tsx
@@ -9,9 +9,9 @@ import { motion } from "motion/react";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import { useShallow } from "zustand/shallow";
-import Avatar from "../avatar";
 import { Button } from "../button";
 import SidebarMenu from "./SidebarMenu";
+import SidebarProfile from "./SidebarProfile";
 import UserGroupList from "./UserGroupList";
 
 function sidebarWidth(isFolded: boolean) {
@@ -53,9 +53,9 @@ export default function Sidebar({ className }: Props) {
       <footer className={clsx("pb-6", isFolded || "px-4")}>
         <div className="border-t border-border-primary pt-5">
           {/* TODO: 로그아웃 상태에서는 info에 undefined/null이 전달되어 '로그인'으로 표시 */}
-          <Profile
+          <SidebarProfile
             isFolded={isFolded}
-            info={{ name: "안해나", team: "경영관리팀" }}
+            userInfo={{ name: "안해나", team: "경영관리팀" }}
           />
         </div>
       </footer>
@@ -140,52 +140,4 @@ function Content({ isFolded }: { isFolded: boolean }) {
 
 function Separator() {
   return <div className="mt-6 mb-3 h-px w-full bg-border-primary" />;
-}
-
-function Profile({
-  isFolded,
-  info,
-}: {
-  isFolded: boolean;
-  info?: {
-    imageUrl?: string;
-    name: string;
-    team: string;
-  };
-}) {
-  const avatar = (
-    <Avatar source={info?.imageUrl} size={isFolded ? "medium" : "large"} />
-  );
-  const title = (
-    <span
-      className={clsx(
-        "text-lg-m whitespace-nowrap",
-        isFolded ? "text-text-default" : "text-text-primary"
-      )}
-    >
-      {info?.name ?? "로그인"}
-    </span>
-  );
-
-  if (isFolded) {
-    return (
-      <button className="flex w-full cursor-pointer justify-center">
-        {info ? avatar : title}
-      </button>
-    );
-  }
-
-  return (
-    <button className="flex cursor-pointer items-center gap-3">
-      {avatar}
-      <div className="flex flex-col items-start gap-0.5">
-        {title}
-        {info?.team && (
-          <span className="text-md-m whitespace-nowrap text-state-400">
-            {info.team}
-          </span>
-        )}
-      </div>
-    </button>
-  );
 }

--- a/src/components/gnb/SidebarProfile.tsx
+++ b/src/components/gnb/SidebarProfile.tsx
@@ -1,5 +1,6 @@
 import Avatar from "@/components/avatar";
 import clsx from "clsx";
+import ProfileMenu from "./ProfileMenu";
 
 interface UserInfo {
   imageUrl?: string;
@@ -20,12 +21,16 @@ export default function SidebarProfile({ isFolded, userInfo }: Props) {
   if (isFolded) {
     return (
       <div className="flex w-full cursor-pointer justify-center">
-        <Avatar source={userInfo.imageUrl} size="medium" />
+        <ProfileMenu
+          anchor={<Avatar source={userInfo.imageUrl} size="medium" />}
+        />
       </div>
     );
   }
 
-  return (
+  const profile = isFolded ? (
+    <Avatar source={userInfo.imageUrl} size="medium" />
+  ) : (
     <div className="flex cursor-pointer items-center gap-3">
       <Avatar source={userInfo.imageUrl} size="large" />
       <div className="flex flex-col items-start gap-0.5">
@@ -36,6 +41,8 @@ export default function SidebarProfile({ isFolded, userInfo }: Props) {
       </div>
     </div>
   );
+
+  return <ProfileMenu anchor={profile} />;
 }
 
 function EmptyProfile({ isFolded }: { isFolded: boolean }) {

--- a/src/components/gnb/SidebarProfile.tsx
+++ b/src/components/gnb/SidebarProfile.tsx
@@ -1,0 +1,87 @@
+import Avatar from "@/components/avatar";
+import clsx from "clsx";
+
+interface UserInfo {
+  imageUrl?: string;
+  name: string;
+  team: string;
+}
+
+interface Props {
+  isFolded: boolean;
+  userInfo?: UserInfo;
+}
+
+export default function SidebarProfile({ isFolded, userInfo }: Props) {
+  if (!userInfo) {
+    return <EmptyProfile isFolded={isFolded} />;
+  }
+
+  if (isFolded) {
+    return (
+      <div className="flex w-full cursor-pointer justify-center">
+        <Avatar source={userInfo.imageUrl} size="medium" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex cursor-pointer items-center gap-3">
+      <Avatar source={userInfo.imageUrl} size="large" />
+      <div className="flex flex-col items-start gap-0.5">
+        <Title>{userInfo.name}</Title>
+        <span className="text-md-m whitespace-nowrap text-state-400">
+          {userInfo.team}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+function EmptyProfile({ isFolded }: { isFolded: boolean }) {
+  const title = <Title isFolded={isFolded}>로그인</Title>;
+
+  const handleClick = () => {
+    // TODO: Go to login page
+  };
+
+  if (isFolded) {
+    return (
+      <button
+        className="flex w-full cursor-pointer justify-center"
+        onClick={handleClick}
+      >
+        {title}
+      </button>
+    );
+  }
+
+  return (
+    <button
+      className="flex cursor-pointer items-center gap-3"
+      onClick={handleClick}
+    >
+      <Avatar size={isFolded ? "medium" : "large"} />
+      <div className="flex flex-col items-start gap-0.5">{title}</div>
+    </button>
+  );
+}
+
+function Title({
+  isFolded = false,
+  children,
+}: {
+  isFolded?: boolean;
+  children: string;
+}) {
+  return (
+    <span
+      className={clsx(
+        "text-lg-m whitespace-nowrap",
+        isFolded ? "text-text-default" : "text-text-primary"
+      )}
+    >
+      {children}
+    </span>
+  );
+}

--- a/src/components/modal/Alert.tsx
+++ b/src/components/modal/Alert.tsx
@@ -1,13 +1,11 @@
 import Icon from "@/components/icon";
+import { type OverlayProps } from "@/components/overlay";
 import { useResponsive } from "@/hooks/use-responsive";
 import { motion } from "motion/react";
 import { ReactNode } from "react";
 import Modal from "./Modal";
 
-interface Props {
-  isOpen: boolean;
-  onClose?: () => void;
-  onExit?: () => void;
+interface Props extends OverlayProps {
   header?: ReactNode;
   title: string;
   message?: string;
@@ -50,7 +48,7 @@ export default function Alert({
           <div className="flex flex-col items-center gap-2">
             <div className="text-lg-m">{title}</div>
             {message && (
-              <div className="text-md-m text-center whitespace-pre-wrap">
+              <div className="text-center text-md-m whitespace-pre-wrap">
                 {message}
               </div>
             )}

--- a/src/components/modal/Modal.tsx
+++ b/src/components/modal/Modal.tsx
@@ -1,45 +1,28 @@
+import Overlay, { type OverlayProps } from "@/components/overlay";
 import { useResponsive } from "@/hooks/use-responsive";
 import clsx from "clsx";
-import { AnimatePresence, motion } from "motion/react";
-import { PropsWithChildren, useEffect } from "react";
-import { createPortal } from "react-dom";
+import { PropsWithChildren } from "react";
 
-interface Props extends PropsWithChildren {
-  isOpen: boolean;
-  onClose?: () => void;
-  onExit?: () => void;
-}
-
-export default function Modal({ isOpen, children, onClose, onExit }: Props) {
+export default function Modal({
+  isOpen,
+  children,
+  onClose,
+  onExit,
+}: PropsWithChildren<OverlayProps>) {
   const { isMobile } = useResponsive();
 
-  useEffect(() => {
-    return () => onExit?.();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  return createPortal(
-    <AnimatePresence>
-      {isOpen && (
-        <motion.div
-          key="modal"
-          className={clsx(
-            "fixed inset-0 z-50 bg-black/50",
-            isMobile && "",
-            isMobile || "flex items-center justify-center"
-          )}
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          exit={{ opacity: 0 }}
-          transition={{ duration: 0.25 }}
-          onClick={onClose}
-        >
-          <div className={clsx(isMobile && "fixed right-0 bottom-0 left-0")}>
-            {children}
-          </div>
-        </motion.div>
-      )}
-    </AnimatePresence>,
-    document.getElementById("modal-root")!
+  return (
+    <Overlay
+      overlayKey="modal"
+      portalId="modal-root"
+      className="tablet:flex tablet:items-center tablet:justify-center"
+      isOpen={isOpen}
+      onClose={onClose}
+      onExit={onExit}
+    >
+      <div className={clsx(isMobile && "fixed right-0 bottom-0 left-0")}>
+        {children}
+      </div>
+    </Overlay>
   );
 }

--- a/src/components/modal/Sheet.tsx
+++ b/src/components/modal/Sheet.tsx
@@ -1,12 +1,10 @@
+import { type OverlayProps } from "@/components/overlay";
 import { useResponsive } from "@/hooks/use-responsive";
 import { motion } from "motion/react";
 import { PropsWithChildren, ReactNode } from "react";
 import Modal from "./Modal";
 
-interface Props {
-  isOpen: boolean;
-  onClose?: () => void;
-  onExit?: () => void;
+interface Props extends OverlayProps {
   title: string;
   message: string;
   content: ReactNode;
@@ -36,7 +34,7 @@ export default function Sheet({
         <div className="flex flex-col">
           <div className="flex flex-col items-center gap-4">
             <div className="text-lg-m">{title}</div>
-            <div className="text-md-m text-center whitespace-pre-wrap text-text-default">
+            <div className="text-center text-md-m whitespace-pre-wrap text-text-default">
               {message}
             </div>
           </div>
@@ -54,7 +52,7 @@ function SheetSection({
 }: PropsWithChildren<{ title: string }>) {
   return (
     <div>
-      <div className="text-lg-m mb-4 text-text-primary">{title}</div>
+      <div className="mb-4 text-lg-m text-text-primary">{title}</div>
       {children}
     </div>
   );

--- a/src/components/overlay/index.tsx
+++ b/src/components/overlay/index.tsx
@@ -1,0 +1,54 @@
+import clsx from "clsx";
+import { AnimatePresence, motion } from "motion/react";
+import { PropsWithChildren } from "react";
+import { createPortal } from "react-dom";
+
+export interface OverlayProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onExit?: () => void;
+}
+
+interface Props extends PropsWithChildren<OverlayProps> {
+  overlayKey?: string;
+  portalId: string;
+  className?: string;
+}
+
+const ANIMATION_DURATION = 0.25;
+
+export default function Overlay({
+  overlayKey,
+  portalId,
+  className,
+  isOpen,
+  children,
+  onClose,
+  onExit,
+}: Props) {
+  const handleClose = () => {
+    onClose();
+    if (onExit) {
+      setTimeout(onExit, ANIMATION_DURATION * 1000);
+    }
+  };
+
+  return createPortal(
+    <AnimatePresence>
+      {isOpen && (
+        <motion.div
+          key={overlayKey ?? "overlay"}
+          className={clsx("fixed inset-0 z-50 bg-black/50", className)}
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={{ duration: ANIMATION_DURATION }}
+          onClick={handleClose}
+        >
+          {children}
+        </motion.div>
+      )}
+    </AnimatePresence>,
+    document.getElementById(portalId)!
+  );
+}

--- a/src/layouts/RootLayout.tsx
+++ b/src/layouts/RootLayout.tsx
@@ -3,9 +3,9 @@ import { PropsWithChildren } from "react";
 
 export default function RootLayout({ children }: PropsWithChildren) {
   return (
-    <div className="flex">
+    <div className="flex h-screen">
       <Sidebar className="relative z-10" />
-      <main className="grow">{children}</main>
+      <main className="grow overflow-y-scroll">{children}</main>
     </div>
   );
 }

--- a/src/layouts/RootLayout.tsx
+++ b/src/layouts/RootLayout.tsx
@@ -4,8 +4,8 @@ import { PropsWithChildren } from "react";
 export default function RootLayout({ children }: PropsWithChildren) {
   return (
     <div className="flex">
-      <Sidebar />
-      <main className="grow overflow-x-hidden">{children}</main>
+      <Sidebar className="relative z-10" />
+      <main className="grow">{children}</main>
     </div>
   );
 }

--- a/src/layouts/RootLayout.tsx
+++ b/src/layouts/RootLayout.tsx
@@ -3,9 +3,9 @@ import { PropsWithChildren } from "react";
 
 export default function RootLayout({ children }: PropsWithChildren) {
   return (
-    <div className="flex h-screen">
+    <div className="flex">
       <Sidebar className="relative z-10" />
-      <main className="grow overflow-y-scroll">{children}</main>
+      <main className="grow">{children}</main>
     </div>
   );
 }

--- a/src/stores/sidebar-store.ts
+++ b/src/stores/sidebar-store.ts
@@ -1,0 +1,12 @@
+import { create } from "zustand";
+import { combine } from "zustand/middleware";
+
+const initialState = {
+  isFold: false,
+};
+
+export const useSidebarStore = create(
+  combine(initialState, (set) => ({
+    toggle: () => set((state) => ({ isFold: !state.isFold })),
+  }))
+);


### PR DESCRIPTION
## 📝 요약

- #43 에 이어서 `Sidebar` UI를 개발합니다.
- 버그 수정 및 개선 작업을 포함합니다.

## ✨ 구현 내용

- Sidebar의 profile을 클릭해서 menu를 표시하도록 구현합니다.
- Sidebar의 fold/unfold 상태를 전역으로 관리할 수 있도록 변경합니다.
- Page에 스크롤이 활성화될 때 Sidebar까지 스크롤 되는 문제를 수정합니다.
- Sidebar를 접었을 때 fold/unfold button 절반이 page에 가려져 클릭할 수 없던 문제를 수정합니다.

### 🎯 실제 결과

| Folded | Unfolded |
|--------|--------|
| <img width="235" height="258" alt="image" src="https://github.com/user-attachments/assets/cc06b6b4-c8b7-438c-9928-e0b34c6e6261" /> | <img width="311" height="258" alt="image" src="https://github.com/user-attachments/assets/2938a5d2-b2cb-4d72-9e41-98f901228ae9" /> | 

---

## 💬 리뷰어 참고 사항 및 알게된 점

- @minyoung1101
  - Sidebar 상태를 전역으로 관리하도록 변경하여 page가 sidebar를 필요에 따라 접을 수 있게 되었습니다.
- Modal과 overlay 관련 수정 사항이 포함되어 있습니다. 원래 이 PR에 넣을만한 내용은 아닌데 햇갈렸습니다 😢 감안해서 리뷰 부탁드립니다.

## ✅ 체크리스트
- [x] 주요 기능 테스트 완료
- [x] 빌드 및 실행 확인
- [x] 커밋 메시지 컨벤션 및 작업 내용 일치 확인