### PR TITLE
[#36] DateSelector 컴포넌트 구현

### DIFF
--- a/src/assets/icons/ic-chevron-left-12.svg
+++ b/src/assets/icons/ic-chevron-left-12.svg
@@ -1,0 +1,3 @@
+<svg width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M7.5 3L4.5 6L7.5 9" stroke="#64748B" stroke-width="1.125" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/assets/icons/ic-chevron-right-12.svg
+++ b/src/assets/icons/ic-chevron-right-12.svg
@@ -1,0 +1,3 @@
+<svg width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M4.5 3L7.5 6L4.5 9" stroke="#64748B" stroke-width="1.125" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/components/icon/icons.ts
+++ b/src/components/icon/icons.ts
@@ -12,8 +12,10 @@ import CheckboxCheckIcon16 from "@/assets/icons/ic-checkbox-check-16.svg";
 import CheckboxCheckIcon18 from "@/assets/icons/ic-checkbox-check-18.svg";
 import ChessIcon20 from "@/assets/icons/ic-chess-20.svg";
 import ChessIcon24 from "@/assets/icons/ic-chess-24.svg";
+import ChevronLeftIcon12 from "@/assets/icons/ic-chevron-left-12.svg";
 import ChevronLeftIcon16 from "@/assets/icons/ic-chevron-left-16.svg";
 import ChevronLeftIcon24 from "@/assets/icons/ic-chevron-left-24.svg";
+import ChevronRightIcon12 from "@/assets/icons/ic-chevron-right-12.svg";
 import ChevronRightIcon16 from "@/assets/icons/ic-chevron-right-16.svg";
 import ChevronRightIcon24 from "@/assets/icons/ic-chevron-right-24.svg";
 import ClockIcon12 from "@/assets/icons/ic-clock-12.svg";
@@ -141,11 +143,13 @@ const Icons: Record<
   },
   chevronLeft: {
     large: ChevronLeftIcon24,
-    small: ChevronLeftIcon16,
+    medium: ChevronLeftIcon16,
+    small: ChevronLeftIcon12,
   },
   chevronRight: {
     large: ChevronRightIcon24,
-    small: ChevronRightIcon16,
+    medium: ChevronRightIcon16,
+    small: ChevronRightIcon12,
   },
   clock: {
     large: ClockIcon16,

--- a/src/features/date-picker/components/BaseDatePicker.tsx
+++ b/src/features/date-picker/components/BaseDatePicker.tsx
@@ -29,6 +29,7 @@ export default function BaseDatePicker({
         mode="single"
         locale={ko}
         selected={selected}
+        defaultMonth={selected}
         onSelect={onSelect}
         onDayClick={onDayClick}
         showOutsideDays

--- a/src/features/tasklist/components/DateNav.tsx
+++ b/src/features/tasklist/components/DateNav.tsx
@@ -1,0 +1,52 @@
+import Icon from "@/components/icon";
+
+interface DateNavProps {
+  selectedDate: Date;
+  onPrev: () => void;
+  onNext: () => void;
+  onOpenCalendar?: () => void;
+}
+
+export default function DateNav({
+  selectedDate,
+  onPrev,
+  onNext,
+  onOpenCalendar,
+}: DateNavProps) {
+  const year = selectedDate.getFullYear();
+  const month = selectedDate.getMonth() + 1;
+
+  return (
+    <div className="flex items-center justify-end gap-2">
+      <span className="text-lg-m text-text-primary">
+        {year}년 {month}월
+      </span>
+
+      <div className="flex items-center gap-2">
+        <button
+          onClick={onPrev}
+          aria-label="이전 달 이동"
+          className="flex h-4 w-4 cursor-pointer items-center justify-center rounded-full border border-state-200 hover:bg-gray-50"
+        >
+          <Icon name="chevronLeft" size="small" color="none" />
+        </button>
+
+        <button
+          onClick={onNext}
+          aria-label="다음 달 이동"
+          className="flex h-4 w-4 cursor-pointer items-center justify-center rounded-full border border-state-200 hover:bg-gray-50"
+        >
+          <Icon name="chevronRight" size="small" color="none" />
+        </button>
+
+        <button
+          onClick={onOpenCalendar}
+          aria-label="날짜 선택창 열기"
+          className="flex h-6 w-6 cursor-pointer items-center justify-center rounded-full bg-background-secondary hover:bg-gray-300"
+        >
+          <Icon name="calendar" size="small" color="icon-primary" />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/features/tasklist/components/DateNav.tsx
+++ b/src/features/tasklist/components/DateNav.tsx
@@ -4,14 +4,14 @@ interface DateNavProps {
   selectedDate: Date;
   onPrev: () => void;
   onNext: () => void;
-  onOpenCalendar?: () => void;
+  onCalendarOpen?: () => void;
 }
 
 export default function DateNav({
   selectedDate,
   onPrev,
   onNext,
-  onOpenCalendar,
+  onCalendarOpen,
 }: DateNavProps) {
   const year = selectedDate.getFullYear();
   const month = selectedDate.getMonth() + 1;
@@ -40,7 +40,7 @@ export default function DateNav({
         </button>
 
         <button
-          onClick={onOpenCalendar}
+          onClick={onCalendarOpen}
           aria-label="날짜 선택창 열기"
           className="flex h-6 w-6 cursor-pointer items-center justify-center rounded-full bg-background-secondary hover:bg-gray-300"
         >

--- a/src/features/tasklist/components/DateSelector.tsx
+++ b/src/features/tasklist/components/DateSelector.tsx
@@ -1,0 +1,60 @@
+import { DatePicker } from "@/features/date-picker";
+import { useState } from "react";
+import DateNav from "./DateNav";
+import DateTabs from "./DateTabs";
+
+interface DateSelectorProps {
+  selectedDate: Date;
+  onSelectDate: (date: Date) => void;
+}
+
+export default function DateSelector({
+  selectedDate,
+  onSelectDate,
+}: DateSelectorProps) {
+  const [openCalendar, setOpenCalendar] = useState(false);
+
+  const handlePrevMonth = () => {
+    const date = new Date(selectedDate);
+    date.setMonth(date.getMonth() - 1);
+    date.setDate(1);
+
+    onSelectDate(date);
+  };
+
+  const handleNextMonth = () => {
+    const date = new Date(selectedDate);
+    date.setMonth(date.getMonth() + 1);
+    date.setDate(1);
+
+    onSelectDate(date);
+  };
+
+  return (
+    <div className="relative flex flex-col gap-4">
+      <DateNav
+        selectedDate={selectedDate}
+        onPrev={handlePrevMonth}
+        onNext={handleNextMonth}
+        onOpenCalendar={() => setOpenCalendar((prev) => !prev)}
+      />
+
+      {/* 임시 DatePicker overlay */}
+      {openCalendar && (
+        <div className="absolute top-8 right-0 z-999 rounded-xl border border-border-primary bg-background-primary p-2 shadow-lg">
+          <DatePicker
+            selected={selectedDate}
+            onSelect={(date) => {
+              if (date) {
+                onSelectDate(date);
+              }
+              setOpenCalendar(false);
+            }}
+          />
+        </div>
+      )}
+
+      <DateTabs selectedDate={selectedDate} onSelect={onSelectDate} />
+    </div>
+  );
+}

--- a/src/features/tasklist/components/DateSelector.tsx
+++ b/src/features/tasklist/components/DateSelector.tsx
@@ -39,7 +39,6 @@ export default function DateSelector({
         onOpenCalendar={() => setOpenCalendar((prev) => !prev)}
       />
 
-      {/* 임시 DatePicker overlay */}
       {openCalendar && (
         <div className="absolute top-8 right-0 z-999 rounded-xl border border-border-primary bg-background-primary p-2 shadow-lg">
           <DatePicker

--- a/src/features/tasklist/components/DateSelector.tsx
+++ b/src/features/tasklist/components/DateSelector.tsx
@@ -5,21 +5,21 @@ import DateTabs from "./DateTabs";
 
 interface DateSelectorProps {
   selectedDate: Date;
-  onSelectDate: (date: Date) => void;
+  onSelect: (date: Date) => void;
 }
 
 export default function DateSelector({
   selectedDate,
-  onSelectDate,
+  onSelect,
 }: DateSelectorProps) {
-  const [openCalendar, setOpenCalendar] = useState(false);
+  const [isCalendarOpen, setisCalendarOpen] = useState(false);
 
   const handlePrevMonth = () => {
     const date = new Date(selectedDate);
     date.setMonth(date.getMonth() - 1);
     date.setDate(1);
 
-    onSelectDate(date);
+    onSelect(date);
   };
 
   const handleNextMonth = () => {
@@ -27,7 +27,7 @@ export default function DateSelector({
     date.setMonth(date.getMonth() + 1);
     date.setDate(1);
 
-    onSelectDate(date);
+    onSelect(date);
   };
 
   return (
@@ -36,24 +36,24 @@ export default function DateSelector({
         selectedDate={selectedDate}
         onPrev={handlePrevMonth}
         onNext={handleNextMonth}
-        onOpenCalendar={() => setOpenCalendar((prev) => !prev)}
+        onCalendarOpen={() => setisCalendarOpen((prev) => !prev)}
       />
 
-      {openCalendar && (
+      {isCalendarOpen && (
         <div className="absolute top-8 right-0 z-999 rounded-xl border border-border-primary bg-background-primary p-2 shadow-lg">
           <DatePicker
             selected={selectedDate}
             onSelect={(date) => {
               if (date) {
-                onSelectDate(date);
+                onSelect(date);
               }
-              setOpenCalendar(false);
+              setisCalendarOpen(false);
             }}
           />
         </div>
       )}
 
-      <DateTabs selectedDate={selectedDate} onSelect={onSelectDate} />
+      <DateTabs selectedDate={selectedDate} onSelect={onSelect} />
     </div>
   );
 }

--- a/src/features/tasklist/components/DateSelector.tsx
+++ b/src/features/tasklist/components/DateSelector.tsx
@@ -40,7 +40,7 @@ export default function DateSelector({
       />
 
       {isCalendarOpen && (
-        <div className="absolute top-8 right-0 z-999 rounded-xl border border-border-primary bg-background-primary p-2 shadow-lg">
+        <div className="absolute top-8 right-0 z-(--z-popover) rounded-xl border border-border-primary bg-background-primary p-2 shadow-lg">
           <DatePicker
             selected={selectedDate}
             onSelect={(date) => {

--- a/src/features/tasklist/components/DateTabs.tsx
+++ b/src/features/tasklist/components/DateTabs.tsx
@@ -14,7 +14,6 @@ const WEEKDAYS = ["일", "월", "화", "수", "목", "금", "토"];
 const SLOT_COUNT = 7;
 const CENTER_INDEX = Math.floor(SLOT_COUNT / 2);
 
-// selectedDate 중앙 기준 7칸 생성
 function getSlotDates(selected: Date) {
   return Array.from({ length: SLOT_COUNT }, (_, i) => {
     const date = new Date(selected);

--- a/src/features/tasklist/components/DateTabs.tsx
+++ b/src/features/tasklist/components/DateTabs.tsx
@@ -1,0 +1,95 @@
+import clsx from "clsx";
+import { motion } from "motion/react";
+import { useState } from "react";
+
+interface DateTabsProps {
+  selectedDate: Date;
+  onSelect: (date: Date) => void;
+  rangeStart?: Date;
+  rangeEnd?: Date;
+}
+
+const WEEKDAYS = ["일", "월", "화", "수", "목", "금", "토"];
+
+const SLOT_COUNT = 7;
+const CENTER_INDEX = Math.floor(SLOT_COUNT / 2);
+
+// selectedDate 중앙 기준 7칸 생성
+function getSlotDates(selected: Date) {
+  return Array.from({ length: SLOT_COUNT }, (_, i) => {
+    const date = new Date(selected);
+    date.setDate(selected.getDate() + (i - CENTER_INDEX));
+    return date;
+  });
+}
+
+function isSameDay(dateA: Date, dateB: Date) {
+  return (
+    dateA.getFullYear() === dateB.getFullYear() &&
+    dateA.getMonth() === dateB.getMonth() &&
+    dateA.getDate() === dateB.getDate()
+  );
+}
+
+export default function DateTabs({ selectedDate, onSelect }: DateTabsProps) {
+  const [direction, setDirection] = useState<"prev" | "next" | null>(null);
+  const dates = getSlotDates(selectedDate);
+
+  const handleSelect = (date: Date) => {
+    if (date > selectedDate) setDirection("next");
+    else if (date < selectedDate) setDirection("prev");
+    onSelect(date);
+  };
+
+  return (
+    <div className="flex items-center gap-1 py-2 tablet:gap-2">
+      <motion.div
+        key={selectedDate.getTime()}
+        initial={{ x: direction === "next" ? 80 : -80, opacity: 0 }}
+        animate={{ x: 0, opacity: 1 }}
+        exit={{ x: direction === "next" ? -80 : 80, opacity: 0 }}
+        transition={{
+          duration: 0.28,
+          ease: [0.22, 1, 0.36, 1], // spring-like easing
+        }}
+        className="flex w-full items-center gap-1 tablet:gap-2"
+      >
+        {dates.map((date) => {
+          const isSelected = isSameDay(date, selectedDate);
+          const day = WEEKDAYS[date.getDay()];
+          const dayNum = date.getDate();
+
+          return (
+            <button
+              key={date.toISOString()}
+              onClick={() => handleSelect(date)}
+              className={clsx(
+                "flex w-full cursor-pointer flex-col items-center justify-center rounded-xl py-2 tablet:px-4 tablet:py-3",
+                isSelected
+                  ? "bg-slate-800 text-text-inverse"
+                  : "border border-border-primary bg-background-primary text-text-primary"
+              )}
+            >
+              <span
+                className={clsx(
+                  "text-xs font-medium",
+                  isSelected ? "text-text-inverse" : "text-text-default"
+                )}
+              >
+                {day}
+              </span>
+              <span
+                className={clsx(
+                  "text-sm-s tablet:text-xl-s",
+                  isSelected ? "text-text-inverse" : "text-text-primary"
+                )}
+              >
+                {dayNum}
+              </span>
+            </button>
+          );
+        })}
+      </motion.div>
+    </div>
+  );
+}

--- a/src/stories/DateSelector.stories.tsx
+++ b/src/stories/DateSelector.stories.tsx
@@ -1,0 +1,34 @@
+import DateSelectorComponent from "@/features/tasklist/components/DateSelector";
+import type { Meta } from "@storybook/react";
+import { useState } from "react";
+
+const meta = {
+  title: "Components/DateSelector",
+  component: DateSelectorComponent,
+  parameters: {
+    layout: "centered",
+  },
+  render: () => <DateSelector />,
+} satisfies Meta<typeof DateSelectorComponent>;
+
+export default meta;
+
+export function DateSelector() {
+  const [selectedDate, setSelectedDate] = useState(new Date());
+
+  return (
+    <div className="w-[500px]">
+      <DateSelectorComponent
+        selectedDate={selectedDate}
+        onSelectDate={setSelectedDate}
+      />
+
+      <div className="mt-4 rounded-md bg-gray-100 p-3">
+        <p className="text-sm text-gray-600">현재 선택된 날짜:</p>
+        <p className="text-md font-semibold">
+          {selectedDate.toLocaleDateString("sv-SE")}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/stories/DateSelector.stories.tsx
+++ b/src/stories/DateSelector.stories.tsx
@@ -20,7 +20,7 @@ export function DateSelector() {
     <div className="w-[500px]">
       <DateSelectorComponent
         selectedDate={selectedDate}
-        onSelectDate={setSelectedDate}
+        onSelect={setSelectedDate}
       />
 
       <div className="mt-4 rounded-md bg-gray-100 p-3">

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -5,6 +5,7 @@
   /* custom tokens */
   --font-sans: "Pretendard", ui-sans-serif, system-ui, sans-serif;
   --z-overlay: 9999;
+  --z-popover: 999;
   --shadow-card: 0px 15px 50px -12px rgba(0, 0, 0, 0.05);
 
   /* Breakpoints */


### PR DESCRIPTION
## 📝 요약
- `DateSelector` 컴포넌트 구현(`DateNav`+`DateTabs`)

## ✨ 구현 내용
- DateNav
  - 현재 선택된 연/월 표시
  - 이전/다음 달 이동 버튼 구현(1일로 이동)
  - 캘린더 버튼 클릭 시 `DatePicker`로 날짜 선택
- DateTabs
  - 선택된 날짜를 중심으로 7일 단위의 날짜 선택 탭 구현
  - framer-motion으로 애니메이션 적용
- DateSelector
  - `DateNav`+`DateTabs`으로 레이아웃 구성
- DatePicker
  - 기존 컴포넌트에서 `selectedDate` 변경 시 월(month)이 변경되지 않는 문제 발견
  - 항상 `selectedDate` 기준으로 렌더링되도록 `defaultMonth` 설정

### 🎯 실제 결과

https://github.com/user-attachments/assets/b3a27d9c-3180-40e1-943a-e79b1ee7a2d3

---

## 💬 리뷰어 참고 사항 및 알게된 점
- ❗chevron icon 12px이 추가되면서 기존 [ large/small ]에서 [ large/medium/small] 으로 옵션이 늘어났습니다
  - chevron 아이콘을 사용하시는 분들은 확인 부탁드립니다!
- 날짜 관련 함수들은 추후 라이브러리 적용 시 수정될 수 있습니다.

## ✅ 체크리스트
- [x] 주요 기능 테스트 완료
- [x] 빌드 및 실행 확인
- [x] 커밋 메시지 컨벤션 및 작업 내용 일치 확인