### PR TITLE
[#35] TaskItem 컴포넌트 구현

### DIFF
--- a/src/components/dropdown/index.tsx
+++ b/src/components/dropdown/index.tsx
@@ -1,6 +1,6 @@
 import { useBackdropClick } from "@/hooks/use-backdrop-click";
 import clsx from "clsx";
-import { CSSProperties, ReactNode, useState } from "react";
+import { CSSProperties, MouseEvent, ReactNode, useState } from "react";
 
 export type Alignment = "top" | "bottom" | "left" | "right" | "fill";
 
@@ -69,18 +69,23 @@ export default function Dropdown({
     callback: () => setIsOpen(false),
   });
 
-  const handleAnchorClick = () => {
+  const handleAnchorClick = (event: MouseEvent) => {
+    event.stopPropagation();
     setIsOpen(!isOpen);
   };
 
-  const handleOptionClick = (option: DropdownOption | string) => {
+  const handleOptionClick = (
+    event: MouseEvent,
+    option: DropdownOption | string
+  ) => {
+    event.stopPropagation();
     onSelect(option);
     setIsOpen(false);
   };
 
   return (
     <div className="relative w-fit" ref={targetRef}>
-      <div onClick={handleAnchorClick}>{anchor}</div>
+      <div onClick={(event) => handleAnchorClick(event)}>{anchor}</div>
       {isOpen && (
         <ul
           className={clsx(
@@ -98,8 +103,8 @@ export default function Dropdown({
             return (
               <li
                 key={key}
-                className="text-lg-r cursor-pointer px-6 py-3.5 whitespace-nowrap hover:bg-background-tertiary"
-                onClick={() => handleOptionClick(option)}
+                className="cursor-pointer px-6 py-3.5 text-lg-r whitespace-nowrap hover:bg-background-tertiary"
+                onClick={(event) => handleOptionClick(event, option)}
               >
                 {label}
               </li>

--- a/src/components/dropdown/index.tsx
+++ b/src/components/dropdown/index.tsx
@@ -85,7 +85,7 @@ export default function Dropdown({
 
   return (
     <div className="relative w-fit" ref={targetRef}>
-      <div onClick={(event) => handleAnchorClick(event)}>{anchor}</div>
+      <div onClick={handleAnchorClick}>{anchor}</div>
       {isOpen && (
         <ul
           className={clsx(

--- a/src/features/tasklist/apis/mock/index.ts
+++ b/src/features/tasklist/apis/mock/index.ts
@@ -1,0 +1,5 @@
+import tasksCommentsMock from "./task-list.json";
+
+export async function getTaskList() {
+  return tasksCommentsMock;
+}

--- a/src/features/tasklist/apis/mock/task-list.json
+++ b/src/features/tasklist/apis/mock/task-list.json
@@ -1,0 +1,32 @@
+[
+  {
+    "id": 1,
+    "name": "업무 A",
+    "description": "",
+    "commentCount": 0,
+    "writer": { "id": 1, "nickname": "홍길동", "image": "" },
+    "doneBy": { "user": { "id": 1, "nickname": "홍길동", "image": "" } },
+    "displayIndex": 0,
+    "frequency": "DAILY",
+    "date": "2025-11-14T21:58:08.308Z",
+    "doneAt": "2025-11-14T21:58:08.308Z",
+    "deletedAt": null,
+    "recurringId": 0,
+    "updatedAt": "2025-11-14T21:58:08.308Z"
+  },
+  {
+    "id": 2,
+    "name": "업무 A",
+    "description": "",
+    "commentCount": 0,
+    "writer": { "id": 1, "nickname": "홍길동", "image": "" },
+    "doneBy": null,
+    "displayIndex": 1,
+    "frequency": "DAILY",
+    "date": "2025-11-14T21:58:08.308Z",
+    "doneAt": null,
+    "deletedAt": null,
+    "recurringId": 0,
+    "updatedAt": "2025-11-14T21:58:08.308Z"
+  }
+]

--- a/src/features/tasklist/components/TaskItem.tsx
+++ b/src/features/tasklist/components/TaskItem.tsx
@@ -64,9 +64,7 @@ export default function TaskItem({ title, tasks, onClick }: TaskItemProps) {
               role="button"
               aria-label="댓글 설정 열기"
               className="cursor-pointer py-1.5"
-              onClick={() => {
-                isDropdownClickRef.current = true;
-              }}
+              onClick={handleDropdownClick}
             >
               <Icon name="dots" size="large" />
             </div>

--- a/src/features/tasklist/components/TaskItem.tsx
+++ b/src/features/tasklist/components/TaskItem.tsx
@@ -4,6 +4,7 @@ import Icon from "@/components/icon";
 import { useResponsive } from "@/hooks/use-responsive";
 import { Task } from "@/types/task";
 import clsx from "clsx";
+import { useRef } from "react";
 
 interface TaskItemProps {
   title: string;
@@ -12,6 +13,7 @@ interface TaskItemProps {
 }
 
 export default function TaskItem({ title, tasks, onClick }: TaskItemProps) {
+  const ignoreItemRef = useRef(false);
   const { isDesktop } = useResponsive();
 
   const totalCount = tasks.length;
@@ -23,12 +25,22 @@ export default function TaskItem({ title, tasks, onClick }: TaskItemProps) {
   ];
 
   const handleSelect = (option: DropdownOption) => {
+    ignoreItemRef.current = true;
+
     switch (option.value) {
       case "edit":
         break;
       case "delete":
         break;
     }
+  };
+
+  const handleItemClick = () => {
+    if (ignoreItemRef.current) {
+      ignoreItemRef.current = false;
+      return;
+    }
+    onClick?.();
   };
 
   return (
@@ -38,7 +50,7 @@ export default function TaskItem({ title, tasks, onClick }: TaskItemProps) {
         isDesktop &&
           "h-[54px] cursor-pointer rounded-xl border border-border-primary pr-3 pl-5"
       )}
-      onClick={onClick}
+      onClick={handleItemClick}
     >
       <span className="text-sm-s desktop:text-md-s">{title}</span>
       <div className="desktop:ml-auto">
@@ -47,13 +59,16 @@ export default function TaskItem({ title, tasks, onClick }: TaskItemProps) {
       {isDesktop && (
         <Dropdown
           anchor={
-            <button
+            <div
+              role="button"
               aria-label="댓글 설정 열기"
               className="cursor-pointer py-1.5"
-              onClick={(e) => e.stopPropagation()}
+              onClick={() => {
+                ignoreItemRef.current = true;
+              }}
             >
               <Icon name="dots" size="large" />
-            </button>
+            </div>
           }
           options={options}
           alignment="right"

--- a/src/features/tasklist/components/TaskItem.tsx
+++ b/src/features/tasklist/components/TaskItem.tsx
@@ -1,0 +1,65 @@
+import DoneBadge from "@/components/badge/DoneBadge";
+import Dropdown, { DropdownOption } from "@/components/dropdown";
+import Icon from "@/components/icon";
+import { useResponsive } from "@/hooks/use-responsive";
+import { Task } from "@/types/task";
+import clsx from "clsx";
+
+interface TaskItemProps {
+  title: string;
+  tasks: Task[];
+  onClick: () => void;
+}
+
+export default function TaskItem({ title, tasks, onClick }: TaskItemProps) {
+  const { isDesktop } = useResponsive();
+
+  const totalCount = tasks.length;
+  const doneCount = tasks.filter((task) => task.doneAt).length;
+
+  const options: DropdownOption[] = [
+    { label: "수정하기", value: "edit" },
+    { label: "삭제하기", value: "delete" },
+  ];
+
+  const handleSelect = (option: DropdownOption) => {
+    switch (option.value) {
+      case "edit":
+        break;
+      case "delete":
+        break;
+    }
+  };
+
+  return (
+    <div
+      className={clsx(
+        "flex items-center justify-start",
+        isDesktop &&
+          "h-[54px] cursor-pointer rounded-xl border border-border-primary pr-3 pl-5"
+      )}
+      onClick={onClick}
+    >
+      <span className="text-sm-s desktop:text-md-s">{title}</span>
+      <div className="desktop:ml-auto">
+        <DoneBadge current={doneCount} total={totalCount} size="small" />
+      </div>
+      {isDesktop && (
+        <Dropdown
+          anchor={
+            <button
+              aria-label="댓글 설정 열기"
+              className="cursor-pointer py-1.5"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <Icon name="dots" size="large" />
+            </button>
+          }
+          options={options}
+          alignment="right"
+          onSelect={(option) => handleSelect(option as DropdownOption)}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/features/tasklist/components/TaskItem.tsx
+++ b/src/features/tasklist/components/TaskItem.tsx
@@ -4,7 +4,6 @@ import Icon from "@/components/icon";
 import { useResponsive } from "@/hooks/use-responsive";
 import { Task } from "@/types/task";
 import clsx from "clsx";
-import { useRef } from "react";
 
 interface TaskItemProps {
   title: string;
@@ -13,7 +12,6 @@ interface TaskItemProps {
 }
 
 export default function TaskItem({ title, tasks, onClick }: TaskItemProps) {
-  const isDropdownClickRef = useRef(false);
   const { isDesktop } = useResponsive();
 
   const totalCount = tasks.length;
@@ -24,24 +22,13 @@ export default function TaskItem({ title, tasks, onClick }: TaskItemProps) {
     { label: "삭제하기", value: "delete" },
   ];
 
-  const handleDropdownClick = () => {
-    isDropdownClickRef.current = true;
-  };
-
   const handleSelect = (option: DropdownOption) => {
-    handleDropdownClick();
-
     switch (option.value) {
       case "edit":
         break;
       case "delete":
         break;
     }
-  };
-
-  const handleItemClick = () => {
-    handleDropdownClick();
-    onClick?.();
   };
 
   return (
@@ -51,7 +38,7 @@ export default function TaskItem({ title, tasks, onClick }: TaskItemProps) {
         isDesktop &&
           "h-[54px] cursor-pointer rounded-xl border border-border-primary pr-3 pl-5"
       )}
-      onClick={handleItemClick}
+      onClick={onClick}
     >
       <span className="text-sm-s desktop:text-md-s">{title}</span>
       <div className="desktop:ml-auto">
@@ -64,7 +51,6 @@ export default function TaskItem({ title, tasks, onClick }: TaskItemProps) {
               role="button"
               aria-label="댓글 설정 열기"
               className="cursor-pointer py-1.5"
-              onClick={handleDropdownClick}
             >
               <Icon name="dots" size="large" />
             </div>

--- a/src/features/tasklist/components/TaskItem.tsx
+++ b/src/features/tasklist/components/TaskItem.tsx
@@ -13,7 +13,7 @@ interface TaskItemProps {
 }
 
 export default function TaskItem({ title, tasks, onClick }: TaskItemProps) {
-  const ignoreItemRef = useRef(false);
+  const isDropdownClickRef = useRef(false);
   const { isDesktop } = useResponsive();
 
   const totalCount = tasks.length;
@@ -25,7 +25,7 @@ export default function TaskItem({ title, tasks, onClick }: TaskItemProps) {
   ];
 
   const handleSelect = (option: DropdownOption) => {
-    ignoreItemRef.current = true;
+    isDropdownClickRef.current = true;
 
     switch (option.value) {
       case "edit":
@@ -36,8 +36,8 @@ export default function TaskItem({ title, tasks, onClick }: TaskItemProps) {
   };
 
   const handleItemClick = () => {
-    if (ignoreItemRef.current) {
-      ignoreItemRef.current = false;
+    if (isDropdownClickRef.current) {
+      isDropdownClickRef.current = false;
       return;
     }
     onClick?.();
@@ -64,7 +64,7 @@ export default function TaskItem({ title, tasks, onClick }: TaskItemProps) {
               aria-label="댓글 설정 열기"
               className="cursor-pointer py-1.5"
               onClick={() => {
-                ignoreItemRef.current = true;
+                isDropdownClickRef.current = true;
               }}
             >
               <Icon name="dots" size="large" />

--- a/src/features/tasklist/components/TaskItem.tsx
+++ b/src/features/tasklist/components/TaskItem.tsx
@@ -24,8 +24,12 @@ export default function TaskItem({ title, tasks, onClick }: TaskItemProps) {
     { label: "삭제하기", value: "delete" },
   ];
 
-  const handleSelect = (option: DropdownOption) => {
+  const handleDropdownClick = () => {
     isDropdownClickRef.current = true;
+  };
+
+  const handleSelect = (option: DropdownOption) => {
+    handleDropdownClick();
 
     switch (option.value) {
       case "edit":
@@ -36,10 +40,7 @@ export default function TaskItem({ title, tasks, onClick }: TaskItemProps) {
   };
 
   const handleItemClick = () => {
-    if (isDropdownClickRef.current) {
-      isDropdownClickRef.current = false;
-      return;
-    }
+    handleDropdownClick();
     onClick?.();
   };
 

--- a/src/stories/TaskItem.stories.tsx
+++ b/src/stories/TaskItem.stories.tsx
@@ -1,0 +1,55 @@
+import TaskItemComponent from "@/features/tasklist/components/TaskItem";
+import type { Task } from "@/types/task";
+import type { Meta, StoryObj } from "@storybook/react";
+
+const meta = {
+  title: "Components/TaskItem",
+  component: TaskItemComponent,
+  parameters: {
+    layout: "centered",
+  },
+} satisfies Meta<typeof TaskItemComponent>;
+
+export default meta;
+type Story = StoryObj<typeof TaskItemComponent>;
+
+const sampleTasks: Task[] = [
+  {
+    id: 1,
+    name: "업무 A",
+    description: "",
+    commentCount: 0,
+    writer: { id: 1, nickname: "홍길동", image: "" },
+    doneBy: { user: { id: 1, nickname: "홍길동", image: "" } },
+    displayIndex: 0,
+    frequency: "DAILY",
+    date: "2025-01-01T00:00:00.000Z",
+    doneAt: "2025-01-01T00:00:00.000Z",
+    deletedAt: null,
+    recurringId: 0,
+    updatedAt: "2025-01-01T00:00:00.000Z",
+  },
+  {
+    id: 2,
+    name: "업무 B",
+    description: "",
+    commentCount: 0,
+    writer: { id: 2, nickname: "이순신", image: "" },
+    doneBy: null,
+    displayIndex: 1,
+    frequency: "DAILY",
+    date: "2025-01-01T00:00:00.000Z",
+    doneAt: null,
+    deletedAt: null,
+    recurringId: 0,
+    updatedAt: "2025-01-01T00:00:00.000Z",
+  },
+];
+
+export const TaskItem: Story = {
+  args: {
+    title: "법인 등기",
+    tasks: sampleTasks,
+    onClick: () => console.log("clicked"),
+  },
+};

--- a/src/types/task.ts
+++ b/src/types/task.ts
@@ -1,0 +1,32 @@
+interface TaskUser {
+  image: string | null;
+  nickname: string;
+  id: number;
+}
+
+export interface Task {
+  doneBy: {
+    user: TaskUser;
+  } | null;
+  writer: TaskUser;
+  displayIndex: number;
+  commentCount: number;
+  deletedAt: string | null;
+  recurringId: number;
+  frequency: "ONCE" | "DAILY" | "MONTHLY" | "WEEKLY";
+  updatedAt: string;
+  doneAt: string | null;
+  date: string;
+  description: string | null;
+  name: string;
+  id: number;
+}
+
+export interface TaskGroup {
+  displayIndex: number;
+  groupId: number;
+  updatedAt: string;
+  createdAt: string;
+  name: string;
+  id: number;
+}


### PR DESCRIPTION
## 📝 요약
- `TaskItem` 컴포넌트 구현

## ✨ 구현 내용
- title prop을 받아 제목 출력
- `tasks` 배열 prop으로 각 항목의 진행도를 계산(뱃지 컴포넌트 사용)
- Dropdown 클릭 시 상위 클릭(onClick)과 충돌하지 않도록 이벤트 버블링 방지 처리

### 🎯 실제 결과
<img width="402" height="190" alt="image" src="https://github.com/user-attachments/assets/d2cc758c-ad8e-49f1-bd3d-b64e90e24922" />

---

## ✅ 체크리스트
- [x] 주요 기능 테스트 완료
- [x] 빌드 및 실행 확인
- [x] 커밋 메시지 컨벤션 및 작업 내용 일치 확인