### PR TITLE
[#37] TodoItem 컴포넌트 구현

### DIFF
--- a/src/features/tasklist/components/TodoItem.tsx
+++ b/src/features/tasklist/components/TodoItem.tsx
@@ -1,0 +1,142 @@
+import Dropdown, { DropdownOption } from "@/components/dropdown";
+import Icon from "@/components/icon";
+import clsx from "clsx";
+import { MouseEvent } from "react";
+
+const spanStyle = "text-xs leading-4 text-text-default no-underline";
+const itemStyle = {
+  container: {
+    base: "bg-background-primary border border-border-primary",
+    selected: "bg-state-50 border border-brand-primary",
+    done: "bg-background-secondary border border-background-secondary",
+    selectedDone: "bg-background-secondary border border-brand-primary",
+  },
+  text: {
+    base: "text-text-primary",
+    selected: "text-text-primary",
+    done: "text-text-disabled  line-through",
+    selectedDone: "text-text-disabled line-through",
+  },
+};
+
+const frequencyDescription = {
+  ONCE: "반복 없음",
+  DAILY: "매일 반복",
+  WEEKLY: "주 반복",
+  MONTHLY: "월 반복",
+};
+
+type taskFrequency = "ONCE" | "DAILY" | "WEEKLY" | "MONTHLY";
+interface TodoItemProps {
+  title: string;
+  commentCount: number;
+  createdAt: string;
+  frequency: taskFrequency;
+  isSelected?: boolean;
+  isDone?: boolean;
+  onToggleDone?: () => void;
+  onItemClick?: () => void;
+}
+
+export default function TodoItem({
+  title,
+  commentCount,
+  createdAt,
+  frequency = "ONCE",
+  isSelected = false,
+  isDone = false,
+  onToggleDone,
+  onItemClick,
+}: TodoItemProps) {
+  const options: DropdownOption[] = [
+    { label: "수정하기", value: "edit" },
+    { label: "삭제하기", value: "delete" },
+  ];
+
+  const handleSelect = (option: DropdownOption) => {
+    switch (option.value) {
+      case "edit":
+        break;
+      case "delete":
+        break;
+    }
+  };
+
+  const handleCheckboxClick = (e: MouseEvent) => {
+    e.stopPropagation();
+    onToggleDone?.();
+  };
+
+  return (
+    <div
+      onClick={onItemClick}
+      className={clsx(
+        "flex w-full cursor-pointer flex-col gap-2.5 rounded-lg px-3.5 py-3",
+        !isSelected && !isDone && itemStyle.container.base,
+        isSelected && !isDone && itemStyle.container.selected,
+        !isSelected && isDone && itemStyle.container.done,
+        isSelected && isDone && itemStyle.container.selectedDone
+      )}
+    >
+      <div className="flex justify-start gap-3">
+        <div className="flex items-center gap-2">
+          <button
+            onClick={handleCheckboxClick}
+            className="cursor-pointer"
+            aria-label={isDone ? "할일 완료 취소하기" : "할일 완료하기"}
+          >
+            <Icon
+              name={isDone ? "checkboxCheck" : "checkbox"}
+              size="small"
+              color="transparent"
+            />
+          </button>
+          <p
+            className={clsx(
+              "line-clamp-1 text-md-r",
+              !isSelected && !isDone && itemStyle.text.base,
+              isSelected && !isDone && itemStyle.text.selected,
+              !isSelected && isDone && itemStyle.text.done,
+              isSelected && isDone && itemStyle.text.selectedDone
+            )}
+          >
+            {title}
+          </p>
+        </div>
+        <div className="flex items-center gap-0.5">
+          <Icon name="comment" size="large" />
+          <span className={spanStyle}>{commentCount}</span>
+        </div>
+        <div className="ml-auto">
+          <Dropdown
+            anchor={
+              <div
+                role="button"
+                aria-label="할일 설정 열기"
+                className="cursor-pointer"
+              >
+                <Icon name="dots" size="small" />
+              </div>
+            }
+            options={options}
+            alignment="right"
+            onSelect={(option) => handleSelect(option as DropdownOption)}
+          />
+        </div>
+      </div>
+      <div className="flex items-center justify-start gap-2.5">
+        <div className="flex items-center gap-1.5">
+          <Icon name="calendar" size="large" />
+          <span className={spanStyle}>{createdAt}</span>
+        </div>
+
+        <div className="h-2 w-px bg-slate-700"></div>
+
+        <div className="flex items-center gap-1.5">
+          <Icon name="repeat" size="large" color="transparent" />
+          <span className={spanStyle}>{frequencyDescription[frequency]}</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/features/tasklist/components/TodoItem.tsx
+++ b/src/features/tasklist/components/TodoItem.tsx
@@ -1,7 +1,9 @@
 import Dropdown, { DropdownOption } from "@/components/dropdown";
 import Icon from "@/components/icon";
+import { TaskFrequency } from "@/types/task";
 import clsx from "clsx";
 import { MouseEvent } from "react";
+import { FREQUENCY_LABEL } from "../constants/task-frequency";
 
 const spanStyle = "text-xs leading-4 text-text-default no-underline";
 const itemStyle = {
@@ -19,19 +21,11 @@ const itemStyle = {
   },
 };
 
-const frequencyDescription = {
-  ONCE: "반복 없음",
-  DAILY: "매일 반복",
-  WEEKLY: "주 반복",
-  MONTHLY: "월 반복",
-};
-
-type taskFrequency = "ONCE" | "DAILY" | "WEEKLY" | "MONTHLY";
 interface TodoItemProps {
   title: string;
   commentCount: number;
   createdAt: string;
-  frequency: taskFrequency;
+  frequency: TaskFrequency;
   isSelected?: boolean;
   isDone?: boolean;
   onToggleDone?: () => void;
@@ -134,7 +128,7 @@ export default function TodoItem({
 
         <div className="flex items-center gap-1.5">
           <Icon name="repeat" size="large" color="transparent" />
-          <span className={spanStyle}>{frequencyDescription[frequency]}</span>
+          <span className={spanStyle}>{FREQUENCY_LABEL[frequency]}</span>
         </div>
       </div>
     </div>

--- a/src/features/tasklist/constants/task-frequency.ts
+++ b/src/features/tasklist/constants/task-frequency.ts
@@ -1,0 +1,8 @@
+import { TaskFrequency } from "@/types/task";
+
+export const FREQUENCY_LABEL: Record<TaskFrequency, string> = {
+  ONCE: "반복 없음",
+  DAILY: "매일 반복",
+  WEEKLY: "주 반복",
+  MONTHLY: "월 반복",
+};

--- a/src/stories/TodoItem.stories.tsx
+++ b/src/stories/TodoItem.stories.tsx
@@ -1,0 +1,40 @@
+import TodoItemComponent from "@/features/tasklist/components/TodoItem";
+import type { Meta, StoryObj } from "@storybook/react";
+
+const meta: Meta<typeof TodoItemComponent> = {
+  title: "Components/TodoItemComponent",
+  component: TodoItemComponent,
+  parameters: {
+    layout: "centered",
+  },
+  argTypes: {
+    isSelected: {
+      control: "boolean",
+      description: "아이템 선택 상태",
+    },
+    isDone: {
+      control: "boolean",
+      description: "할일 완료 여부",
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof TodoItemComponent>;
+
+export const TodoItem: Story = {
+  args: {
+    title: "법인 설립 비용 안내 드리기",
+    commentCount: 3,
+    createdAt: "2024년 7월 29일",
+    frequency: "DAILY",
+    isSelected: false,
+    isDone: false,
+  },
+  render: (args) => (
+    <div className="w-[400px]">
+      <TodoItemComponent {...args} />
+    </div>
+  ),
+};

--- a/src/types/task.ts
+++ b/src/types/task.ts
@@ -30,3 +30,5 @@ export interface TaskGroup {
   name: string;
   id: number;
 }
+
+export type TaskFrequency = "ONCE" | "DAILY" | "WEEKLY" | "MONTHLY";


### PR DESCRIPTION
## 📝 요약
- TodoItem 컴포넌트 구현

## ✨ 구현 내용
- `TodoItem` UI 컴포넌트 생성 및 상태별 스타일(base / selected / done) 적용
- props 기반으로 제목, 댓글 수, 작성 날짜, 반복 설정 UI 출력

### 🎯 실제 결과
<img width="536" height="612" alt="image" src="https://github.com/user-attachments/assets/1fbb280d-83f7-40b0-bc66-252a563603cf" />

---

## 💬 리뷰어 참고 사항 및 알게된 점
- 급하게 작업하느라 커밋 분리가 너무 안된 것 같습니다🫠 다음에는 더 신경쓰겠습니다!

## ✅ 체크리스트
- [x] 주요 기능 테스트 완료
- [x] 빌드 및 실행 확인
- [x] 커밋 메시지 컨벤션 및 작업 내용 일치 확인