### PR TITLE
[#73] Icon / Dropdown 컴포넌트 수정

### DIFF
--- a/src/assets/icons/ic-plus-16.svg
+++ b/src/assets/icons/ic-plus-16.svg
@@ -1,4 +1,4 @@
-<svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="none" xmlns="http://www.w3.org/2000/svg">
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" xmlns="http://www.w3.org/2000/svg">
 <path d="M4 8H12.5" stroke-width="2" stroke-linecap="round"/>
 <path d="M8.25 12.25V3.75" stroke-width="2" stroke-linecap="round"/>
 </svg>

--- a/src/assets/icons/ic-plus-24.svg
+++ b/src/assets/icons/ic-plus-24.svg
@@ -1,4 +1,4 @@
-<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="none" xmlns="http://www.w3.org/2000/svg">
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" xmlns="http://www.w3.org/2000/svg">
 <path d="M6 12H18.75" stroke-width="3" stroke-linecap="round"/>
 <path d="M12.375 18.375V5.625" stroke-width="3" stroke-linecap="round"/>
 </svg>

--- a/src/components/button/FloatingButton.tsx
+++ b/src/components/button/FloatingButton.tsx
@@ -1,13 +1,11 @@
-import { IconName } from "@/components/icon/icons";
 import clsx from "clsx";
-import { MouseEventHandler } from "react";
-import Icon from "../icon";
+import { MouseEventHandler, ReactNode } from "react";
 
 type Variant = "primary" | "inverse";
 
 interface Props {
   variant?: Variant;
-  iconName: IconName;
+  icon: ReactNode;
   onClick?: MouseEventHandler<HTMLButtonElement>;
 }
 
@@ -24,7 +22,7 @@ const border: Record<Variant, string> = {
 
 export default function FloatingButton({
   variant = "primary",
-  iconName,
+  icon,
   onClick,
 }: Props) {
   return (
@@ -36,9 +34,7 @@ export default function FloatingButton({
       )}
       onClick={onClick}
     >
-      <div className="size-6 -translate-x-[0.5px]">
-        <Icon name={iconName} color="white" />
-      </div>
+      <div className="size-6 -translate-x-[0.5px]">{icon}</div>
     </button>
   );
 }

--- a/src/components/button/FloatingButton.tsx
+++ b/src/components/button/FloatingButton.tsx
@@ -37,7 +37,7 @@ export default function FloatingButton({
       onClick={onClick}
     >
       <div className="size-6 -translate-x-[0.5px]">
-        <Icon name={iconName} />
+        <Icon name={iconName} color="white" />
       </div>
     </button>
   );

--- a/src/components/dropdown/index.tsx
+++ b/src/components/dropdown/index.tsx
@@ -7,7 +7,7 @@ export type Alignment = "top" | "bottom" | "left" | "right" | "fill";
 export type Direction = "top" | "bottom" | "left" | "right";
 
 export interface DropdownOption {
-  label: string;
+  label: ReactNode;
   value: string;
 }
 

--- a/src/components/dropdown/index.tsx
+++ b/src/components/dropdown/index.tsx
@@ -19,7 +19,7 @@ interface Props {
   direction?: Direction;
   alignment?: Alignment;
   alignmentOffset?: number;
-  onSelect: (option: DropdownOption | string) => void;
+  onSelect?: (option: DropdownOption | string) => void;
 }
 
 type Edge = Pick<CSSProperties, "top" | "left" | "right" | "bottom">;
@@ -80,7 +80,7 @@ export default function Dropdown({
     option: DropdownOption | string
   ) => {
     event.stopPropagation();
-    onSelect(option);
+    onSelect?.(option);
     if (typeof option !== "string") {
       option.action?.();
     }

--- a/src/components/dropdown/index.tsx
+++ b/src/components/dropdown/index.tsx
@@ -80,11 +80,20 @@ export default function Dropdown({
     option: DropdownOption | string
   ) => {
     event.stopPropagation();
-    onSelect?.(option);
-    if (typeof option !== "string") {
-      option.action?.();
+
+    if (isStringOption(option)) {
+      onSelect?.(option);
+    } else if (option.action) {
+      option.action();
+    } else {
+      onSelect?.(option);
     }
+
     setIsOpen(false);
+  };
+
+  const isStringOption = (option: DropdownOption | string) => {
+    return typeof option === "string";
   };
 
   return (
@@ -102,8 +111,8 @@ export default function Dropdown({
           style={layoutStyles({ gap, direction, alignment, alignmentOffset })}
         >
           {options.map((option) => {
-            const key = typeof option === "string" ? option : option.value;
-            const label = typeof option === "string" ? option : option.label;
+            const key = isStringOption(option) ? option : option.value;
+            const label = isStringOption(option) ? option : option.label;
             return (
               <li
                 key={key}

--- a/src/components/dropdown/index.tsx
+++ b/src/components/dropdown/index.tsx
@@ -9,6 +9,7 @@ export type Direction = "top" | "bottom" | "left" | "right";
 export interface DropdownOption {
   label: ReactNode;
   value: string;
+  action?: () => void;
 }
 
 interface Props {
@@ -80,6 +81,9 @@ export default function Dropdown({
   ) => {
     event.stopPropagation();
     onSelect(option);
+    if (typeof option !== "string") {
+      option.action?.();
+    }
     setIsOpen(false);
   };
 

--- a/src/components/icon/index.tsx
+++ b/src/components/icon/index.tsx
@@ -9,5 +9,5 @@ export interface IconProps {
 
 export default function Icon({ name, size = "large", color }: IconProps) {
   const Component = Icons[name][size];
-  return Component ? <Component color={color} fill={color} /> : null;
+  return Component && <Component color={color} fill={color} />;
 }

--- a/src/components/icon/index.tsx
+++ b/src/components/icon/index.tsx
@@ -9,5 +9,5 @@ export interface IconProps {
 
 export default function Icon({ name, size = "large", color }: IconProps) {
   const Component = Icons[name][size];
-  return Component && <Component color={color} fill={color} />;
+  return Component && <Component color={color} fill={color} stroke={color} />;
 }


### PR DESCRIPTION
## 📝 요약
- Icon / Dropdown 컴포넌트 수정

## ✨ 구현 내용
### Icon
- stroke 적용 추가 (fill/stroke를 동일하게 color로 처리)
- plus 아이콘의 stroke-width가 적용되지 않던 문제 해결 (`stroke="currentColor"`로 명시)
- FloatingButton 아이콘 색상 white로 일관 적용

### Dropdown
- `DropdownOption.label`을 `ReactNode`로 변경
- 옵션별 실행을 위한 `action` 콜백 추가
- `onSelect`를 optional로 변경

---

## 💬 리뷰어 참고 사항 및 알게된 점
### Icon 컴포넌트 `color="transparent"`
- 팀미팅에서는 `color="transparent"`를 기본값으로 두자고 말씀을 드렸었는데요,
- 그렇게되면 Button처럼 className 기반으로 색을 스타일링하는 경우에는
  `color` prop이 우선 적용되는 문제가 있어 기본값 추가는 제외했습니다.
- `SearchBar`처럼 stroke만 필요한 경우 `color="transparent"`를 명시적으로 전달해야 합니다.

### `stroke-width`
- SVG에 `stroke="none"`이 있으면 최적화 과정에서 stroke 관련 속성(`stroke-width` 등)이 모두 제거되는 문제가 있었습니다.
- 만약 사용하는 아이콘의 stroke 굵기가 적용이 되지않는다면 이 부분도 확인해보시면 좋을 것 같습니다.

## ✅ 체크리스트
- [x] 주요 기능 테스트 완료
- [x] 빌드 및 실행 확인
- [x] 커밋 메시지 컨벤션 및 작업 내용 일치 확인