### PR TITLE
Config 테일윈드 css 린트 설정 (표준클래스 미사용시 경고 표시)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,6 @@
     "source.fixAll": "explicit",
     "source.fixAll.eslint": "explicit",
     "source.organizeImports": "explicit"
-  }
+  },
+  "tailwindCSS.lint.suggestCanonicalClasses": "warning"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,5 +6,5 @@
     "source.fixAll.eslint": "explicit",
     "source.organizeImports": "explicit"
   },
-  "tailwindCSS.lint.suggestCanonicalClasses": "warning"
+  "tailwindCSS.lint.suggestCanonicalClasses": "warning" //테일윈드 표준클래스 린트 설정
 }


### PR DESCRIPTION
## 📝 요약
테일윈드css 표준클래스 미사용시 노란색 밑줄로 경고를 알려줍니다

## ✨ 구현 내용
Tailwind CSS IntelliSense 설치 및 vscode/settings.json에 해당 내용을 추가합니다

### 🎯 실제 결과
<img width="735" height="313" alt="테일윈드 표준클래스 " src="https://github.com/user-attachments/assets/0e97a553-ce35-422b-a129-969f95b0605d" />



### 📸 참고 자료

## 💬 리뷰어 참고 사항 및 알게된 점
위처럼 h-[28px]등 테일윈드 표준 클래스가 있는 경우에는 표준클래스로 사용하도록 사용자에게 알려줍니다


## ✅ 체크리스트
- [x] 주요 기능 테스트 완료
- [x] 빌드 및 실행 확인
- [x] 커밋 메시지 컨벤션 및 작업 내용 일치 확인