### PR TITLE
[#117] Sidebar fold 상태 유지

### DIFF
--- a/src/stores/sidebar-store.ts
+++ b/src/stores/sidebar-store.ts
@@ -1,13 +1,21 @@
 import { create } from "zustand";
-import { combine } from "zustand/middleware";
+import { persist } from "zustand/middleware";
 
-const initialState = {
-  isFold: false,
-};
+interface SidebarStore {
+  isFold: boolean;
+  setFold: (isFold: boolean) => void;
+  toggle: () => void;
+}
 
-export const useSidebarStore = create(
-  combine(initialState, (set) => ({
-    toggle: () => set((state) => ({ isFold: !state.isFold })),
-    setFold: (folded: boolean) => set(() => ({ isFold: folded })),
-  }))
+export const useSidebarStore = create<SidebarStore>()(
+  persist(
+    (set) => ({
+      isFold: false,
+      setFold: (isFold: boolean) => set(() => ({ isFold: isFold })),
+      toggle: () => set((state) => ({ isFold: !state.isFold })),
+    }),
+    {
+      name: "sidebar-fold-storage",
+    }
+  )
 );


### PR DESCRIPTION
## 📝 요약

- 페이지를 새로고침하거나 다른 페이지로 이동할 때 Sidebar fold 상태가 유지되도록 개발합니다.

## ✨ 구현 내용

- Sidebar store에 `persist` middleware를 사용해서 상탯값이 local storage에 저장되도록 구현합니다.

---

## ✅ 체크리스트
- [x] 주요 기능 테스트 완료
- [x] 빌드 및 실행 확인
- [x] 커밋 메시지 컨벤션 및 작업 내용 일치 확인