### PR TITLE
[#116] Sidebar 팀 목록 개선

### DIFF
--- a/src/components/gnb/common/UserGroupList.tsx
+++ b/src/components/gnb/common/UserGroupList.tsx
@@ -1,5 +1,9 @@
+import Icon from "@/components/icon";
+import { useResponsive } from "@/hooks/use-responsive";
 import { UserGroup } from "@/types/group";
+import clsx from "clsx";
 import Link from "next/link";
+import { useState } from "react";
 import SidebarMenu from "./SidebarMenu";
 
 interface Props {
@@ -13,20 +17,57 @@ export default function UserGroupList({
   compact = false,
   activeGroupId,
 }: Props) {
+  const { isMobile } = useResponsive();
+  const [openDropdown, setOpenDropdown] = useState(false);
+
+  const handleDropdownClick = () => {
+    setOpenDropdown(!openDropdown);
+  };
+
   return (
-    <ul className="flex flex-col tablet:gap-2">
-      {groups.map((group) => (
-        <li key={group.id}>
-          <Link href={`/${group.id}`}>
-            <SidebarMenu
-              iconName="chess"
-              title={group.name}
-              compact={compact}
-              active={group.id === activeGroupId}
-            />
-          </Link>
-        </li>
-      ))}
-    </ul>
+    <div className="flex flex-col gap-2">
+      {isMobile || compact || (
+        <Dropdown isOpen={openDropdown} onClick={handleDropdownClick} />
+      )}
+      {openDropdown && (
+        <ul className="flex flex-col tablet:gap-2">
+          {groups.map((group) => (
+            <li key={group.id}>
+              <Link href={`/${group.id}`}>
+                <SidebarMenu
+                  iconName="chess"
+                  title={group.name}
+                  compact={compact}
+                  active={group.id === activeGroupId}
+                />
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+function Dropdown({
+  isOpen,
+  onClick,
+}: {
+  isOpen: boolean;
+  onClick?: () => void;
+}) {
+  return (
+    <div
+      className="flex cursor-pointer items-center rounded-lg px-4 py-2 hover:bg-state-50"
+      onClick={onClick}
+    >
+      <div className="flex grow items-center gap-3">
+        <Icon name="chess" size="small" color="#cbd5e1" />
+        <span className="text-lg-s text-state-400">팀 선택</span>
+      </div>
+      <div className={clsx(isOpen && "rotate-180")}>
+        <Icon name="triangleDown" size="small" />
+      </div>
+    </div>
   );
 }

--- a/src/components/gnb/common/UserGroupList.tsx
+++ b/src/components/gnb/common/UserGroupList.tsx
@@ -1,9 +1,10 @@
 import Icon from "@/components/icon";
 import { useResponsive } from "@/hooks/use-responsive";
+import { useSidebarStore } from "@/stores/sidebar-store";
 import { UserGroup } from "@/types/group";
 import clsx from "clsx";
 import Link from "next/link";
-import { useState } from "react";
+import { useShallow } from "zustand/shallow";
 import SidebarMenu from "./SidebarMenu";
 
 interface Props {
@@ -18,18 +19,20 @@ export default function UserGroupList({
   activeGroupId,
 }: Props) {
   const { isMobile } = useResponsive();
-  const [openDropdown, setOpenDropdown] = useState(false);
+  const [isDropdownOpen, toggleDropdownOpen] = useSidebarStore(
+    useShallow((state) => [state.isDropdownOpen, state.toggleDropdownOpen])
+  );
 
   const handleDropdownClick = () => {
-    setOpenDropdown(!openDropdown);
+    toggleDropdownOpen();
   };
 
   return (
     <div className="flex flex-col gap-2">
       {isMobile || compact || (
-        <Dropdown isOpen={openDropdown} onClick={handleDropdownClick} />
+        <Dropdown isOpen={isDropdownOpen} onClick={handleDropdownClick} />
       )}
-      {(isMobile || openDropdown) && (
+      {(isMobile || isDropdownOpen) && (
         <ul className="flex max-h-[220px] flex-col overflow-y-scroll tablet:max-h-[292px] tablet:gap-2">
           {groups.map((group) => (
             <li key={group.id}>

--- a/src/components/gnb/common/UserGroupList.tsx
+++ b/src/components/gnb/common/UserGroupList.tsx
@@ -29,8 +29,8 @@ export default function UserGroupList({
       {isMobile || compact || (
         <Dropdown isOpen={openDropdown} onClick={handleDropdownClick} />
       )}
-      {openDropdown && (
-        <ul className="flex flex-col tablet:gap-2">
+      {(isMobile || openDropdown) && (
+        <ul className="flex max-h-[220px] flex-col overflow-y-scroll tablet:max-h-[292px] tablet:gap-2">
           {groups.map((group) => (
             <li key={group.id}>
               <Link href={`/${group.id}`}>

--- a/src/components/gnb/sidebar/Sidebar.tsx
+++ b/src/components/gnb/sidebar/Sidebar.tsx
@@ -110,7 +110,7 @@ function FoldButton({
 
 function Content({ isFolded }: { isFolded: boolean }) {
   const router = useRouter();
-  const { userGroups } = useUserGroupsQuery();
+  const { userGroups, isPending, isFetching } = useUserGroupsQuery();
 
   const handleAddTeamClick = () => {
     router.push("/addteam");
@@ -123,6 +123,7 @@ function Content({ isFolded }: { isFolded: boolean }) {
         isFolded ? "items-center" : "px-4"
       )}
     >
+      {(isPending || isFetching) && <UserGroupListLoadingSkeleton />}
       {userGroups && (
         <div className="flex flex-col gap-2">
           <UserGroupList
@@ -152,6 +153,19 @@ function Content({ isFolded }: { isFolded: boolean }) {
           active={router.pathname === "/boards"}
         />
       </Link>
+    </div>
+  );
+}
+
+function UserGroupListLoadingSkeleton() {
+  return (
+    <div className="flex w-full flex-col gap-2">
+      {Array.from({ length: 3 }).map((_, index) => (
+        <div
+          key={index}
+          className="h-13 animate-pulse rounded-xl bg-background-secondary"
+        />
+      ))}
     </div>
   );
 }

--- a/src/components/gnb/sidebar/Sidebar.tsx
+++ b/src/components/gnb/sidebar/Sidebar.tsx
@@ -29,8 +29,8 @@ interface Props {
 }
 
 export default function Sidebar({ className }: Props) {
-  const [isFolded, toggle, setFold] = useSidebarStore(
-    useShallow((state) => [state.isFold, state.toggle, state.setFold])
+  const [isFolded, toggleFold, setFold] = useSidebarStore(
+    useShallow((state) => [state.isFold, state.toggleFold, state.setFold])
   );
   const [isLoggedIn, user] = useAuthStore(
     useShallow((state) => [state.loggedIn, state.user])
@@ -38,7 +38,7 @@ export default function Sidebar({ className }: Props) {
   useResponsive({ onTablet: setFold });
 
   const handleFoldClick = () => {
-    toggle();
+    toggleFold();
   };
 
   if (!isLoggedIn) {

--- a/src/features/user/query/use-user-query.tsx
+++ b/src/features/user/query/use-user-query.tsx
@@ -12,10 +12,10 @@ export function useUserQuery() {
 }
 
 export function useUserGroupsQuery() {
-  const { data } = useQuery({
+  const { data, isPending, isFetching } = useQuery({
     queryKey: userGroupsQueryKey,
     queryFn: getUserGroups,
   });
 
-  return { userGroups: data };
+  return { userGroups: data, isPending, isFetching };
 }

--- a/src/stores/sidebar-store.ts
+++ b/src/stores/sidebar-store.ts
@@ -5,6 +5,8 @@ interface SidebarStore {
   isFold: boolean;
   setFold: (isFold: boolean) => void;
   toggle: () => void;
+  isDropdownOpen: boolean;
+  toggleDropdownOpen: () => void;
 }
 
 export const useSidebarStore = create<SidebarStore>()(
@@ -13,6 +15,9 @@ export const useSidebarStore = create<SidebarStore>()(
       isFold: false,
       setFold: (isFold: boolean) => set(() => ({ isFold: isFold })),
       toggle: () => set((state) => ({ isFold: !state.isFold })),
+      isDropdownOpen: true,
+      toggleDropdownOpen: () =>
+        set((state) => ({ isDropdownOpen: !state.isDropdownOpen })),
     }),
     {
       name: "sidebar-fold-storage",

--- a/src/stores/sidebar-store.ts
+++ b/src/stores/sidebar-store.ts
@@ -4,7 +4,7 @@ import { persist } from "zustand/middleware";
 interface SidebarStore {
   isFold: boolean;
   setFold: (isFold: boolean) => void;
-  toggle: () => void;
+  toggleFold: () => void;
   isDropdownOpen: boolean;
   toggleDropdownOpen: () => void;
 }
@@ -14,7 +14,7 @@ export const useSidebarStore = create<SidebarStore>()(
     (set) => ({
       isFold: false,
       setFold: (isFold: boolean) => set(() => ({ isFold: isFold })),
-      toggle: () => set((state) => ({ isFold: !state.isFold })),
+      toggleFold: () => set((state) => ({ isFold: !state.isFold })),
       isDropdownOpen: true,
       toggleDropdownOpen: () =>
         set((state) => ({ isDropdownOpen: !state.isDropdownOpen })),


### PR DESCRIPTION
## 📝 요약

- Sidebar의 팀 목록을 개선합니다.

## ✨ 구현 내용

- 팀 목록 로딩 중 skeleton loading animation을 적용합니다.
- 팀 목록을 접었다 펼 수 있는 dropdown UI를 구현합니다.
- 팀 목록에 scroll을 적용합니다.

### 🎯 실제 결과

https://github.com/user-attachments/assets/e2122a44-6477-4426-86d7-f53e88ce3283

---

## ✅ 체크리스트
- [x] 주요 기능 테스트 완료
- [x] 빌드 및 실행 확인
- [x] 커밋 메시지 컨벤션 및 작업 내용 일치 확인