### PR TITLE
[#120] Overlay(Modal) 닫기 관련 설정 추가

### DIFF
--- a/src/components/modal/Alert.tsx
+++ b/src/components/modal/Alert.tsx
@@ -18,6 +18,7 @@ export default function Alert({
   isOpen,
   onClose,
   onExit,
+  dismissable,
   header,
   title,
   message,
@@ -28,7 +29,12 @@ export default function Alert({
   const { isMobile } = useResponsive();
 
   return (
-    <Modal isOpen={isOpen} onClose={onClose} onExit={onExit}>
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      onExit={onExit}
+      dismissable={dismissable}
+    >
       <motion.div
         className={
           "rounded-t-3xl bg-background-primary px-4 pt-4 pb-8 tablet:w-[384px] tablet:rounded-3xl"

--- a/src/components/modal/Alert.tsx
+++ b/src/components/modal/Alert.tsx
@@ -18,7 +18,7 @@ export default function Alert({
   isOpen,
   onClose,
   onExit,
-  dismissable,
+  allowsBackgroundDismiss,
   header,
   title,
   message,
@@ -33,7 +33,7 @@ export default function Alert({
       isOpen={isOpen}
       onClose={onClose}
       onExit={onExit}
-      dismissable={dismissable}
+      allowsBackgroundDismiss={allowsBackgroundDismiss}
     >
       <motion.div
         className={

--- a/src/components/modal/Modal.tsx
+++ b/src/components/modal/Modal.tsx
@@ -8,7 +8,7 @@ export default function Modal({
   children,
   onClose,
   onExit,
-  dismissable,
+  allowsBackgroundDismiss,
 }: PropsWithChildren<OverlayProps>) {
   const { isMobile } = useResponsive();
 
@@ -24,7 +24,7 @@ export default function Modal({
       isOpen={isOpen}
       onClose={onClose}
       onExit={onExit}
-      dismissable={dismissable}
+      allowsBackgroundDismiss={allowsBackgroundDismiss}
     >
       <div
         className={clsx(isMobile && "fixed right-0 bottom-0 left-0")}

--- a/src/components/modal/Modal.tsx
+++ b/src/components/modal/Modal.tsx
@@ -8,6 +8,7 @@ export default function Modal({
   children,
   onClose,
   onExit,
+  dismissable,
 }: PropsWithChildren<OverlayProps>) {
   const { isMobile } = useResponsive();
 
@@ -23,6 +24,7 @@ export default function Modal({
       isOpen={isOpen}
       onClose={onClose}
       onExit={onExit}
+      dismissable={dismissable}
     >
       <div
         className={clsx(isMobile && "fixed right-0 bottom-0 left-0")}

--- a/src/components/overlay/index.tsx
+++ b/src/components/overlay/index.tsx
@@ -7,6 +7,7 @@ export interface OverlayProps {
   isOpen: boolean;
   onClose: () => void;
   onExit?: () => void;
+  dismissable?: boolean;
 }
 
 interface Props extends PropsWithChildren<OverlayProps> {
@@ -21,11 +22,17 @@ export default function Overlay({
   overlayKey,
   portalId,
   className,
+  dismissable = true,
   isOpen,
   children,
   onClose,
   onExit,
 }: Props) {
+  const handleBackgroundClick = () => {
+    if (!dismissable) return;
+    onClose();
+  };
+
   return createPortal(
     <AnimatePresence onExitComplete={onExit}>
       {isOpen && (
@@ -36,7 +43,7 @@ export default function Overlay({
           animate={{ opacity: 1 }}
           exit={{ opacity: 0 }}
           transition={{ duration: ANIMATION_DURATION }}
-          onClick={onClose}
+          onClick={handleBackgroundClick}
         >
           {children}
         </motion.div>

--- a/src/components/overlay/index.tsx
+++ b/src/components/overlay/index.tsx
@@ -7,7 +7,7 @@ export interface OverlayProps {
   isOpen: boolean;
   onClose: () => void;
   onExit?: () => void;
-  dismissable?: boolean;
+  allowsBackgroundDismiss?: boolean;
 }
 
 interface Props extends PropsWithChildren<OverlayProps> {
@@ -22,14 +22,14 @@ export default function Overlay({
   overlayKey,
   portalId,
   className,
-  dismissable = true,
+  allowsBackgroundDismiss = true,
   isOpen,
   children,
   onClose,
   onExit,
 }: Props) {
   const handleBackgroundClick = () => {
-    if (!dismissable) return;
+    if (!allowsBackgroundDismiss) return;
     onClose();
   };
 

--- a/src/features/group/components/TeamEditPageBase.tsx
+++ b/src/features/group/components/TeamEditPageBase.tsx
@@ -1,9 +1,8 @@
 import { Button } from "@/components/button";
-import { TextField } from "@/components/input";
+import { AvatarInput, TextField } from "@/components/input";
 import { ErrorAlert } from "@/components/modal";
 import { useGroupMutation } from "@/features/group/query/use-group-mutation";
 import TeamEditContainer from "@/features/team/components/TeamEditContainer";
-import TeamEditImageInput from "@/features/team/components/TeamEditImageInput";
 import { useResponsive } from "@/hooks/use-responsive";
 import { Group } from "@/types/group";
 import { useRouter } from "next/router";
@@ -77,10 +76,7 @@ export default function TeamEditPageBase({ group }: Props) {
         footer="팀 이름은 회사명이나 모임 이름 등으로 설정하면 좋아요."
       >
         <div className="flex flex-col items-center">
-          <TeamEditImageInput
-            source={group?.image}
-            onChange={handleFileChange}
-          />
+          <AvatarInput source={group?.image} onChange={handleFileChange} />
           <div className="mt-6 flex w-full flex-col gap-3">
             <label htmlFor={textFieldId} className="text-md-m tablet:text-lg-m">
               팀 이름

--- a/src/pages/jointeam/index.tsx
+++ b/src/pages/jointeam/index.tsx
@@ -54,6 +54,8 @@ export default function JoinTeamPage() {
                 onClick={handleTeamPageClick}
               />,
             ]}
+            showsCloseButton={false}
+            dismissable={false}
           />
         );
       },

--- a/src/pages/jointeam/index.tsx
+++ b/src/pages/jointeam/index.tsx
@@ -55,7 +55,7 @@ export default function JoinTeamPage() {
               />,
             ]}
             showsCloseButton={false}
-            dismissable={false}
+            allowsBackgroundDismiss={false}
           />
         );
       },


### PR DESCRIPTION
## 📝 요약

- Overlay를 사용하는 modal 요소에서 배경 클릭 또는 'X' 버튼을 클릭해서 닫는 기능을 비활성화 할 수 있는 옵션을 추가합니다.

## ✨ 구현 내용

- `allowsBackgroundDismissable` : `false`로 설정하면 Modal 요소의 dimmed background를 클릭했을 때 modal을 닫지 않습니다. (기본값 `true`)
- 팀 참여 시 '대시보드 이동' 또는 '팀 이동' 둘 중 하나의 action을 반드시 선택할 수 있도록 'X' 버튼 클릭 및 background 클릭으로 alert을 닫지 못하도록 설정합니다.

---

## 💬 리뷰어 참고 사항 및 알게된 점
리뷰어가 중점적으로 확인해야 할 부분이나, 개발 중 새로 알게 된 점이 있다면 작성해주세요.

## ✅ 체크리스트
- [x] 주요 기능 테스트 완료
- [x] 빌드 및 실행 확인
- [x] 커밋 메시지 컨벤션 및 작업 내용 일치 확인