### PR TITLE
[#123] 비밀번호 재설정 기능 개발

### DIFF
--- a/src/components/input/PasswordInputLabel.tsx
+++ b/src/components/input/PasswordInputLabel.tsx
@@ -1,0 +1,45 @@
+import InputLabel from "@/features/login/components/InputLabel";
+import PasswordVisible from "@/features/login/components/PasswordVisible";
+
+interface Props {
+  id: string;
+  label: string;
+  value: string;
+  placeholder: string;
+  errorMessage?: string;
+  visible: boolean;
+  onChange: (value: string) => void;
+  onBlur: () => void;
+  onVisibleChange: () => void;
+}
+
+export default function PasswordInputLabel({
+  id,
+  label,
+  value,
+  placeholder,
+  errorMessage,
+  visible,
+  onChange,
+  onBlur,
+  onVisibleChange,
+}: Props) {
+  const VisibleButton = (
+    <PasswordVisible isVisible={visible} onToggle={onVisibleChange} />
+  );
+
+  return (
+    <InputLabel
+      label={label}
+      id={id}
+      type={visible ? "text" : "password"}
+      placeholder={placeholder}
+      size="large"
+      value={value}
+      onChange={(event) => onChange(event.target.value)}
+      onBlur={onBlur}
+      errorMessage={errorMessage}
+      trailing={VisibleButton}
+    />
+  );
+}

--- a/src/features/auth/components/ResetPasswordAlert.tsx
+++ b/src/features/auth/components/ResetPasswordAlert.tsx
@@ -1,0 +1,112 @@
+import { Button } from "@/components/button";
+import { Input } from "@/components/input";
+import { Alert } from "@/components/modal";
+import { OverlayProps } from "@/components/overlay";
+import { useResetPasswordMutation } from "@/features/user/query";
+import { overlay } from "overlay-kit";
+import { useState } from "react";
+
+export default function ResetPasswordAlert({
+  isOpen,
+  onClose,
+  onExit,
+}: OverlayProps) {
+  const [resetEmail, setResetEmail] = useState("");
+  const { postResetPasswordMutation } = useResetPasswordMutation();
+
+  const handleEmailChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setResetEmail(event.target.value);
+  };
+
+  const handleNestedExit = (nestedUnmount: () => void) => {
+    nestedUnmount();
+    onExit?.();
+  };
+
+  const handleSuccess = (message: string) => {
+    overlay.open(({ isOpen, close, unmount }) => (
+      <NestedAlert
+        isOpen={isOpen}
+        onClose={close}
+        onExit={() => handleNestedExit(unmount)}
+        message={message}
+      />
+    ));
+  };
+
+  const handleError = (error: Error) => {
+    overlay.open(({ isOpen, close, unmount }) => (
+      <NestedAlert
+        isOpen={isOpen}
+        onClose={close}
+        onExit={() => handleNestedExit(unmount)}
+        message={error.message}
+      />
+    ));
+  };
+
+  const handleSendLinkClick = () => {
+    postResetPasswordMutation.mutate(
+      { email: resetEmail },
+      {
+        onSuccess: handleSuccess,
+        onError: handleError,
+      }
+    );
+    onClose();
+  };
+
+  return (
+    <Alert
+      isOpen={isOpen}
+      onClose={onClose}
+      title="비밀번호 재설정"
+      message="비밀번호 재설정 링크를 보내드립니다."
+      content={
+        <Input
+          type="email"
+          value={resetEmail}
+          placeholder="이메일을 입력하세요."
+          size="large"
+          onChange={handleEmailChange}
+        />
+      }
+      actions={[
+        <Button
+          key="reset-password-alert-close"
+          title="닫기"
+          variant="outlinedPrimary"
+          isFullWidth={true}
+          onClick={onClose}
+        />,
+        <Button
+          key="reset-password-alert-send"
+          title="링크 보내기"
+          isFullWidth={true}
+          onClick={handleSendLinkClick}
+        />,
+      ]}
+    />
+  );
+}
+
+function NestedAlert({
+  isOpen,
+  onClose,
+  onExit,
+  message,
+}: OverlayProps & { message: string }) {
+  return (
+    <Alert
+      isOpen={isOpen}
+      onClose={onClose}
+      onExit={onExit}
+      title="재설정 이메일 전송"
+      message={message}
+      actions={[
+        <Button key="nested-alert-confirm" title="확인" onClick={onClose} />,
+      ]}
+      showsCloseButton={false}
+    />
+  );
+}

--- a/src/features/auth/components/ResetPasswordAlert.tsx
+++ b/src/features/auth/components/ResetPasswordAlert.tsx
@@ -12,7 +12,7 @@ export default function ResetPasswordAlert({
   onExit,
 }: OverlayProps) {
   const [resetEmail, setResetEmail] = useState("");
-  const { postResetPasswordMutation } = useResetPasswordMutation();
+  const { postMutation } = useResetPasswordMutation();
 
   const handleEmailChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setResetEmail(event.target.value);
@@ -46,7 +46,7 @@ export default function ResetPasswordAlert({
   };
 
   const handleSendLinkClick = () => {
-    postResetPasswordMutation.mutate(
+    postMutation.mutate(
       { email: resetEmail },
       {
         onSuccess: handleSuccess,

--- a/src/features/user/apis/index.ts
+++ b/src/features/user/apis/index.ts
@@ -14,3 +14,28 @@ export async function getUserGroups() {
   const response = await clientApiInstance.get<UserGroup[]>("/user/groups");
   return response.data;
 }
+
+interface PostResetPasswordParams {
+  email: string;
+}
+
+interface PostResetPasswordResponse {
+  message: string;
+}
+
+export async function postResetPassword({ email }: PostResetPasswordParams) {
+  const redirectUrl =
+    process.env.NODE_ENV === "production"
+      ? process.env.NEXT_PUBLIC_APP_URL
+      : "http://localhost:3000";
+
+  try {
+    const response = await clientApiInstance.post<PostResetPasswordResponse>(
+      "/user/send-reset-password-email",
+      { email, redirectUrl }
+    );
+    return response.data.message;
+  } catch {
+    throw Error("가입되지 않은 이메일입니다. 이메일 주소를 확인해주세요.");
+  }
+}

--- a/src/features/user/apis/index.ts
+++ b/src/features/user/apis/index.ts
@@ -2,6 +2,7 @@ import { apiRequest, APIRequestOptions } from "@/services/api-request";
 import { clientApiInstance } from "@/services/instance/client";
 import { UserGroup } from "@/types/group";
 import { User } from "@/types/user";
+import { isAxiosError } from "axios";
 
 export async function getUser(options?: APIRequestOptions) {
   return apiRequest<User>(async (instance) => {
@@ -37,5 +38,29 @@ export async function postResetPassword({ email }: PostResetPasswordParams) {
     return response.data.message;
   } catch {
     throw Error("가입되지 않은 이메일입니다. 이메일 주소를 확인해주세요.");
+  }
+}
+
+interface PatchResetPasswordParams {
+  password: string;
+  confirmedPassword: string;
+  token: string;
+}
+
+export async function patchResetPassword({
+  password,
+  confirmedPassword,
+  token,
+}: PatchResetPasswordParams) {
+  try {
+    const response = await clientApiInstance.patch<PostResetPasswordResponse>(
+      "/user/reset-password",
+      { password, passwordConfirmation: confirmedPassword, token }
+    );
+    return response.data.message;
+  } catch (error) {
+    if (isAxiosError(error)) {
+      throw Error(error.response?.data.message);
+    }
   }
 }

--- a/src/features/user/query/index.ts
+++ b/src/features/user/query/index.ts
@@ -1,2 +1,3 @@
 export { prefetchUser } from "./prefetch-user";
+export { useResetPasswordMutation } from "./use-user-mutation";
 export { useUserGroupsQuery, useUserQuery } from "./use-user-query";

--- a/src/features/user/query/use-user-mutation.tsx
+++ b/src/features/user/query/use-user-mutation.tsx
@@ -1,0 +1,10 @@
+import { useMutation } from "@tanstack/react-query";
+import { postResetPassword } from "../apis";
+
+export function useResetPasswordMutation() {
+  const postResetPasswordMutation = useMutation({
+    mutationFn: postResetPassword,
+  });
+
+  return { postResetPasswordMutation };
+}

--- a/src/features/user/query/use-user-mutation.tsx
+++ b/src/features/user/query/use-user-mutation.tsx
@@ -1,10 +1,14 @@
 import { useMutation } from "@tanstack/react-query";
-import { postResetPassword } from "../apis";
+import { patchResetPassword, postResetPassword } from "../apis";
 
 export function useResetPasswordMutation() {
-  const postResetPasswordMutation = useMutation({
+  const postMutation = useMutation({
     mutationFn: postResetPassword,
   });
 
-  return { postResetPasswordMutation };
+  const patchMutation = useMutation({
+    mutationFn: patchResetPassword,
+  });
+
+  return { postMutation, patchMutation };
 }

--- a/src/layouts/PageLayout.tsx
+++ b/src/layouts/PageLayout.tsx
@@ -1,0 +1,15 @@
+import clsx from "clsx";
+import { HTMLAttributes, PropsWithChildren } from "react";
+
+export default function PageLayout({
+  className,
+  children,
+}: PropsWithChildren & HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div className="h-full bg-background-secondary">
+      <div className={clsx("h-full w-full max-w-7xl", className)}>
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -1,7 +1,7 @@
 import KakaotalkIcon from "@/assets/icons/ic-kakaotalk.svg";
 import { Button } from "@/components/button";
-import { Alert } from "@/components/modal";
 import { postSignIn } from "@/features/auth/apis";
+import ResetPasswordAlert from "@/features/auth/components/ResetPasswordAlert";
 import InputLabel from "@/features/login/components/InputLabel";
 import PasswordVisible from "@/features/login/components/PasswordVisible";
 import { useAuthStore } from "@/stores/auth-store";
@@ -82,39 +82,7 @@ export default function LoginPage() {
   const handleForgotPasswordClick = () => {
     overlay.open(
       ({ isOpen, close, unmount }) => (
-        <Alert
-          isOpen={isOpen}
-          onClose={close}
-          onExit={unmount}
-          title="비밀번호 재설정"
-          message="비밀번호 재설정 링크를 보내드립니다."
-          content={
-            <InputLabel
-              label=""
-              type="email"
-              placeholder="이메일을 입력하세요."
-              size="large"
-            />
-          }
-          actions={[
-            <Button
-              key="close"
-              title="닫기"
-              variant="outlinedPrimary"
-              size="large"
-              isFullWidth={true}
-              onClick={close}
-            />,
-            <Button
-              key="send"
-              title="링크 보내기"
-              variant="primary"
-              size="large"
-              isFullWidth={true}
-              onClick={close}
-            />,
-          ]}
-        />
+        <ResetPasswordAlert isOpen={isOpen} onClose={close} onExit={unmount} />
       ),
       { overlayId: "password-reset-alert" }
     );

--- a/src/pages/reset-password/index.tsx
+++ b/src/pages/reset-password/index.tsx
@@ -1,0 +1,3 @@
+export default function ResetPasswordPage() {
+  return <h1> 비밀번호 재설정 페이지 </h1>;
+}

--- a/src/pages/reset-password/index.tsx
+++ b/src/pages/reset-password/index.tsx
@@ -1,3 +1,102 @@
+import { Button } from "@/components/button";
+import PasswordInputLabel from "@/components/input/PasswordInputLabel";
+import PageLayout from "@/layouts/PageLayout";
+import {
+  validatePassword,
+  validatePasswordConfirm,
+} from "@/utils/login-validator";
+import { MouseEvent, useState } from "react";
+
+interface StateValue {
+  password: string;
+  confirmedPassword: string;
+}
+
+const INITIAL_STATE_VALUE: StateValue = {
+  password: "",
+  confirmedPassword: "",
+};
+
 export default function ResetPasswordPage() {
-  return <h1> 비밀번호 재설정 페이지 </h1>;
+  const [value, setValue] = useState(INITIAL_STATE_VALUE);
+  const [errorMessage, setErrorMessage] = useState(INITIAL_STATE_VALUE);
+  const [visible, setVisible] = useState(false);
+
+  const canSubmit =
+    value.password !== "" &&
+    value.confirmedPassword !== "" &&
+    errorMessage.password === "" &&
+    errorMessage.confirmedPassword === "";
+
+  const handlePasswordChange = (value: string) => {
+    setValue((prev) => ({ ...prev, password: value }));
+  };
+
+  const handlePasswordBlur = () => {
+    const result = validatePassword(value.password);
+    setErrorMessage((prev) => ({
+      ...prev,
+      password: result.valid ? "" : result.reason!,
+    }));
+  };
+
+  const handleConfirmedPasswordChange = (value: string) => {
+    setValue((prev) => ({ ...prev, confirmedPassword: value }));
+  };
+
+  const handleConfirmPasswordBlur = () => {
+    const result = validatePasswordConfirm(
+      value.password,
+      value.confirmedPassword
+    );
+    setErrorMessage((prev) => ({
+      ...prev,
+      confirmedPassword: result.valid ? "" : result.reason!,
+    }));
+  };
+
+  const handleSubmit = (event: MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+    console.log("Resetting password with values:", value);
+  };
+
+  return (
+    <PageLayout className="flex items-center justify-center px-4 tablet:px-6">
+      <div className="w-full max-w-[550px] rounded-[20px] bg-background-primary px-[22px] py-[52px] tablet:px-[45px] tablet:py-[71px]">
+        <h1 className="text-center text-xl-b text-text-primary tablet:text-2xl-b">
+          비밀번호 재설정
+        </h1>
+        <form className="mt-8 flex flex-col gap-6 tablet:mt-16">
+          <PasswordInputLabel
+            label="비밀번호"
+            id="password"
+            value={value.password}
+            placeholder="비밀번호를 입력해주세요."
+            onChange={handlePasswordChange}
+            onBlur={handlePasswordBlur}
+            errorMessage={errorMessage.password}
+            visible={visible}
+            onVisibleChange={() => setVisible(!visible)}
+          />
+          <PasswordInputLabel
+            label="비밀번호 확인"
+            id="confirmPassword"
+            value={value.confirmedPassword}
+            placeholder="비밀번호를 다시 한 번 입력해주세요."
+            onChange={handleConfirmedPasswordChange}
+            onBlur={handleConfirmPasswordBlur}
+            errorMessage={errorMessage.confirmedPassword}
+            visible={visible}
+            onVisibleChange={() => setVisible(!visible)}
+          />
+        </form>
+        <Button
+          className="mt-10"
+          title="비밀번호 재설정"
+          onClick={handleSubmit}
+          disabled={!canSubmit}
+        />
+      </div>
+    </PageLayout>
+  );
 }

--- a/src/pages/reset-password/index.tsx
+++ b/src/pages/reset-password/index.tsx
@@ -1,10 +1,14 @@
 import { Button } from "@/components/button";
 import PasswordInputLabel from "@/components/input/PasswordInputLabel";
+import { Alert, ErrorAlert } from "@/components/modal";
+import { useResetPasswordMutation } from "@/features/user/query";
 import PageLayout from "@/layouts/PageLayout";
 import {
   validatePassword,
   validatePasswordConfirm,
 } from "@/utils/login-validator";
+import { useRouter } from "next/router";
+import { overlay } from "overlay-kit";
 import { MouseEvent, useState } from "react";
 
 interface StateValue {
@@ -21,6 +25,9 @@ export default function ResetPasswordPage() {
   const [value, setValue] = useState(INITIAL_STATE_VALUE);
   const [errorMessage, setErrorMessage] = useState(INITIAL_STATE_VALUE);
   const [visible, setVisible] = useState(false);
+  const router = useRouter();
+  const { token } = router.query;
+  const { patchMutation } = useResetPasswordMutation();
 
   const canSubmit =
     value.password !== "" &&
@@ -55,9 +62,54 @@ export default function ResetPasswordPage() {
     }));
   };
 
+  const handleSuccess = () => {
+    overlay.open(({ isOpen, close, unmount }) => {
+      const handleClick = () => {
+        router.push("/login");
+        close();
+      };
+
+      return (
+        <Alert
+          isOpen={isOpen}
+          onClose={close}
+          onExit={unmount}
+          title="비밀번호 재설정 성공"
+          message="비밀번호가 성공적으로 재설정되었습니다."
+          actions={[
+            <Button key="confirm" title="로그인 하기" onClick={handleClick} />,
+          ]}
+          showsCloseButton={false}
+        />
+      );
+    });
+  };
+
+  const handleError = (error: Error) => {
+    overlay.open(({ isOpen, close, unmount }) => (
+      <ErrorAlert
+        isOpen={isOpen}
+        onClose={close}
+        onExit={unmount}
+        title="비밀번호 재설정 실패"
+        error={error}
+      />
+    ));
+  };
+
   const handleSubmit = (event: MouseEvent<HTMLButtonElement>) => {
     event.preventDefault();
-    console.log("Resetting password with values:", value);
+    patchMutation.mutate(
+      {
+        password: value.password,
+        confirmedPassword: value.confirmedPassword,
+        token: token as string,
+      },
+      {
+        onSuccess: handleSuccess,
+        onError: handleError,
+      }
+    );
   };
 
   return (

--- a/src/providers/AuthProvider.tsx
+++ b/src/providers/AuthProvider.tsx
@@ -8,17 +8,17 @@ import { useShallow } from "zustand/shallow";
 
 export default function AuthProvider({ children }: PropsWithChildren) {
   const router = useRouter();
-  const [login, logout] = useAuthStore(
-    useShallow((state) => [state.logIn, state.logOut])
+  const [login, logout, refreshToken] = useAuthStore(
+    useShallow((state) => [state.logIn, state.logOut, state.refreshToken])
   );
-  const refreshToken = useAuthStore((state) => state.refreshToken);
 
   const initializeAuth = async () => {
-    try {
-      if (["/", "/login", "/signup"].includes(router.pathname)) {
-        return;
-      }
+    const excludedPaths = ["/", "/login", "/signup", "/reset-password"];
+    if (excludedPaths.includes(router.pathname)) {
+      return;
+    }
 
+    try {
       const accessToken = await postRefreshToken();
       refreshToken({ accessToken });
 

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -8,15 +8,16 @@ export async function proxy(request: NextRequest) {
   const isLoginOrSignupPage = ["/login", "/signup"].includes(
     request.nextUrl.pathname
   );
+  const isResetPasswordPage = request.nextUrl.pathname === "/reset-password";
 
   if (isValidToken) {
-    if (isLoginOrSignupPage) {
+    if (isLoginOrSignupPage || isResetPasswordPage) {
       return redirect("/dashboard", request.url);
     } else {
       return next();
     }
   } else {
-    if (isLandingPage || isLoginOrSignupPage) {
+    if (isLandingPage || isLoginOrSignupPage || isResetPasswordPage) {
       return next();
     } else {
       return redirect("/login", request.url);
@@ -43,6 +44,7 @@ export const config = {
     "/myhistory",
     "/mypage",
     "/boards",
+    "/reset-password",
     "/:teamid",
     "/:teamid/tasklist",
     "/:teamid/:taskid",


### PR DESCRIPTION
## 📝 요약

- 비밀번호를 재설정하는 기능을 개발합니다.

## ✨ 구현 내용

- 로그인 화면에서 재설정 alert에 email을 입력하고 전송 버튼을 누르면, 비밀번호를 재설정하는 url이 담긴 메일을 받습니다.
  - 이 때, 회원가입하지 않은 email을 사용하는 경우 error alert을 표시합니다.
- 메일에서 '비밀번호 재설정' 링크를 클릭하면, 재설정 POST API를 전송할 때 설정한 `redirectUrl`에 `token` query string이 붙은 URL로 이동합니다.
- 비밀번호 재설정 page는 로그인/회원가입 페이지를 참고해서 새로 만들었습니다. 이 페이지에서 비밀번호 입력 후 '비밀번호 재설정' 버튼을 누르면 비밀번호 변경 PATCH API 요청을 보냅니다.
  - 실패 응답이 돌아오면 error alert을 보여줍이다.
  - 성공 응답이 돌아오면 성공 alert을 보여준 후, '확인' 버튼을 클릭하면 로그인 페이지로 이동합니다.

### 🎯 실제 결과

- 재설정 이메일 전송 성공 시 alert
  <img width="404" height="231" alt="image" src="https://github.com/user-attachments/assets/e85a8bcf-839b-4e70-ad28-6ae375775472" />
- 비밀번호 재설정 email 도착 
  <img width="408" height="238" alt="image" src="https://github.com/user-attachments/assets/47974d70-a2d1-48f3-8bc8-6094ccfb06bf" />
- 비밀번호 재설정 화면
  <img width="1260" height="821" alt="image" src="https://github.com/user-attachments/assets/7c391a19-9818-413b-9fb9-a7b8d73b7cfb" />
- 비밀번호 재설정 성공 alert
  <img width="561" height="364" alt="image" src="https://github.com/user-attachments/assets/89e94627-3fe4-400d-a184-4bdf82fc75f1" />

---

## 💬 리뷰어 참고 사항 및 알게된 점

- 비밀번호 입력 폼은 회원가입 페이지의 구현을 참고했습니다.

## ✅ 체크리스트
- [x] 주요 기능 테스트 완료
- [x] 빌드 및 실행 확인
- [x] 커밋 메시지 컨벤션 및 작업 내용 일치 확인