### PR TITLE
[#122] 마이 히스토리 페이지 개발

### DIFF
--- a/src/components/gnb/common/ProfileMenu.tsx
+++ b/src/components/gnb/common/ProfileMenu.tsx
@@ -30,7 +30,7 @@ export default function ProfileMenu({
     {
       label: "마이 히스토리",
       value: "myhistory",
-      action: () => console.log("Go to my history"),
+      action: () => router.push("/myhistory"),
     },
     {
       label: "계정 설정",

--- a/src/features/user/apis/index.ts
+++ b/src/features/user/apis/index.ts
@@ -1,6 +1,7 @@
 import { apiRequest, APIRequestOptions } from "@/services/api-request";
 import { clientApiInstance } from "@/services/instance/client";
 import { UserGroup } from "@/types/group";
+import { TaskHistory } from "@/types/task";
 import { User } from "@/types/user";
 import { isAxiosError } from "axios";
 
@@ -14,6 +15,15 @@ export async function getUser(options?: APIRequestOptions) {
 export async function getUserGroups() {
   const response = await clientApiInstance.get<UserGroup[]>("/user/groups");
   return response.data;
+}
+
+export async function getUserHistory(options?: APIRequestOptions) {
+  return apiRequest<TaskHistory[]>(async (instance) => {
+    const response = await instance.get<{ tasksDone: TaskHistory[] }>(
+      "/user/history"
+    );
+    return response.data.tasksDone;
+  }, options);
 }
 
 interface PostResetPasswordParams {

--- a/src/features/user/query/index.ts
+++ b/src/features/user/query/index.ts
@@ -1,3 +1,7 @@
-export { prefetchUser } from "./prefetch-user";
+export { prefetchUser, prefetchUserHistory } from "./prefetch-user";
 export { useResetPasswordMutation } from "./use-user-mutation";
-export { useUserGroupsQuery, useUserQuery } from "./use-user-query";
+export {
+  useUserGroupsQuery,
+  useUserHistoryQuery,
+  useUserQuery,
+} from "./use-user-query";

--- a/src/features/user/query/prefetch-user.tsx
+++ b/src/features/user/query/prefetch-user.tsx
@@ -1,5 +1,6 @@
 import { QueryClient } from "@tanstack/react-query";
-import { getUser } from "../apis";
+import { getUser, getUserHistory } from "../apis";
+import { USER_HISTORY_QUERY_KEY } from "./query-key";
 
 interface Props {
   accessToken: string;
@@ -12,5 +13,15 @@ export async function prefetchUser(
   await queryClient.prefetchQuery({
     queryKey: ["user"],
     queryFn: () => getUser({ accessToken }),
+  });
+}
+
+export async function prefetchUserHistory(
+  queryClient: QueryClient,
+  { accessToken }: Props
+) {
+  await queryClient.prefetchQuery({
+    queryKey: USER_HISTORY_QUERY_KEY,
+    queryFn: () => getUserHistory({ accessToken }),
   });
 }

--- a/src/features/user/query/query-key.ts
+++ b/src/features/user/query/query-key.ts
@@ -1,1 +1,3 @@
 export const userGroupsQueryKey = ["user", "groups"] as const;
+
+export const USER_HISTORY_QUERY_KEY = ["user", "history"] as const;

--- a/src/features/user/query/use-user-query.tsx
+++ b/src/features/user/query/use-user-query.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
-import { getUser, getUserGroups } from "../apis";
-import { userGroupsQueryKey } from "./query-key";
+import { getUser, getUserGroups, getUserHistory } from "../apis";
+import { USER_HISTORY_QUERY_KEY, userGroupsQueryKey } from "./query-key";
 
 export function useUserQuery() {
   const { data } = useQuery({
@@ -18,4 +18,14 @@ export function useUserGroupsQuery() {
   });
 
   return { userGroups: data, isPending, isFetching };
+}
+
+export function useUserHistoryQuery() {
+  const { data } = useQuery({
+    queryKey: USER_HISTORY_QUERY_KEY,
+    queryFn: () => getUserHistory(),
+    refetchOnMount: "always",
+  });
+
+  return { history: data };
 }

--- a/src/pages/myhistory/index.tsx
+++ b/src/pages/myhistory/index.tsx
@@ -1,10 +1,12 @@
+import Icon from "@/components/icon";
+import { FREQUENCY_LABEL } from "@/features/tasklist/constants/task-frequency";
 import {
   prefetchUserHistory,
   useUserHistoryQuery,
 } from "@/features/user/query";
-import PageLayout from "@/layouts/PageLayout";
 import { gsspPropsWithTokenReturn } from "@/libs/ssr/gssp-return";
 import { gsspWithAuth } from "@/libs/ssr/with-auth";
+import { TaskHistory } from "@/types/task";
 import { dehydrate, QueryClient } from "@tanstack/react-query";
 
 export const getServerSideProps = gsspWithAuth(async (context, accessToken) => {
@@ -20,16 +22,48 @@ export default function MyHistoryPage() {
   const { history } = useUserHistoryQuery();
 
   return (
-    <PageLayout>
-      <header>My History</header>
-      <ul>
-        {history &&
-          history.map((item) => (
-            <li key={item.id}>
-              <div>{item.name}</div>
-            </li>
-          ))}
-      </ul>
-    </PageLayout>
+    <div className="h-full bg-background-primary">
+      <div className="h-full w-full max-w-7xl">
+        <div className="flex flex-col gap-8 p-4 tablet:px-6 tablet:py-20 desktop:p-20">
+          <header className="text-xl-b text-text-primary tablet:text-2xl-b">
+            My History
+          </header>
+          <ul className="flex flex-col gap-4">
+            {history &&
+              history.map((item) => (
+                <li key={item.id}>
+                  <DoneTask task={item} />
+                </li>
+              ))}
+          </ul>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function DoneTask({ task }: { task: TaskHistory }) {
+  return (
+    <div className="flex flex-col gap-2.5 rounded-xl bg-background-secondary px-4 py-3.5">
+      <div className="flex gap-2">
+        <Icon name="checkboxCheck" size="small" />
+        <span className="text-sm-r text-text-disabled line-through tablet:text-md-r">
+          {task.name}
+        </span>
+      </div>
+      <div className="flex items-center gap-2.5">
+        <div className="flex items-center gap-2">
+          <Icon name="calendar" size="large" />
+          <span className="text-xs-r text-text-default">{task.doneAt}</span>
+        </div>
+        <div className="h-2 w-px border border-l-text-secondary" />
+        <div className="flex items-center gap-2">
+          <Icon name="repeat" size="large" color="var(--color-icon-primary)" />
+          <span className="text-xs-r text-text-default">
+            {FREQUENCY_LABEL[task.frequency]}
+          </span>
+        </div>
+      </div>
+    </div>
   );
 }

--- a/src/pages/myhistory/index.tsx
+++ b/src/pages/myhistory/index.tsx
@@ -1,0 +1,35 @@
+import {
+  prefetchUserHistory,
+  useUserHistoryQuery,
+} from "@/features/user/query";
+import PageLayout from "@/layouts/PageLayout";
+import { gsspPropsWithTokenReturn } from "@/libs/ssr/gssp-return";
+import { gsspWithAuth } from "@/libs/ssr/with-auth";
+import { dehydrate, QueryClient } from "@tanstack/react-query";
+
+export const getServerSideProps = gsspWithAuth(async (context, accessToken) => {
+  const queryClient = new QueryClient();
+  await prefetchUserHistory(queryClient, { accessToken });
+  return gsspPropsWithTokenReturn({
+    accessToken,
+    dehydratedState: dehydrate(queryClient),
+  });
+});
+
+export default function MyHistoryPage() {
+  const { history } = useUserHistoryQuery();
+
+  return (
+    <PageLayout>
+      <header>My History</header>
+      <ul>
+        {history &&
+          history.map((item) => (
+            <li key={item.id}>
+              <div>{item.name}</div>
+            </li>
+          ))}
+      </ul>
+    </PageLayout>
+  );
+}

--- a/src/types/task.ts
+++ b/src/types/task.ts
@@ -47,3 +47,18 @@ export interface TaskComment {
   content: string;
   id: number;
 }
+
+export interface TaskHistory {
+  displayIndex: number;
+  writerId: number;
+  userId: number;
+  deletedAt: string;
+  frequency: TaskFrequency;
+  description: string;
+  name: string;
+  recurringId: number;
+  doneAt: string;
+  date: string;
+  updatedAt: string;
+  id: number;
+}


### PR DESCRIPTION
## 📝 요약

- 마이 히스토리 페이지(`/myhistory`)를 개발합니다.

## ✨ 구현 내용

- 마이 히스토리 페이지를 개발할 때 사용하는 `/user/history` API 응답 구조상 시안 2의 UI로 개발하는 데에 무리가 있습니다.
- 시안 1의 layout에 시안 2의 theme을 적용해서 단순히 history를 나열하는 방식으로 구현합니다.

### 🎯 실제 결과

<img width="1099" height="675" alt="image" src="https://github.com/user-attachments/assets/3c4c2317-d3d6-4733-864a-9bad4a0a1ca8" />

---

## ✅ 체크리스트
- [x] 주요 기능 테스트 완료
- [x] 빌드 및 실행 확인
- [x] 커밋 메시지 컨벤션 및 작업 내용 일치 확인