### PR TITLE
[#105] 계정설정 페이지 비밀번호 변경 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -97,7 +97,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz",
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -3122,7 +3121,8 @@
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-android-arm64": {
       "version": "4.52.5",
@@ -3135,7 +3135,8 @@
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
       "version": "4.52.5",
@@ -3148,7 +3149,8 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-darwin-x64": {
       "version": "4.52.5",
@@ -3161,7 +3163,8 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
       "version": "4.52.5",
@@ -3174,7 +3177,8 @@
       "optional": true,
       "os": [
         "freebsd"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
       "version": "4.52.5",
@@ -3187,7 +3191,8 @@
       "optional": true,
       "os": [
         "freebsd"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
       "version": "4.52.5",
@@ -3200,7 +3205,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
       "version": "4.52.5",
@@ -3213,7 +3219,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
       "version": "4.52.5",
@@ -3226,7 +3233,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
       "version": "4.52.5",
@@ -3239,7 +3247,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
       "version": "4.52.5",
@@ -3252,7 +3261,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
       "version": "4.52.5",
@@ -3265,7 +3275,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
       "version": "4.52.5",
@@ -3278,7 +3289,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
       "version": "4.52.5",
@@ -3291,7 +3303,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
       "version": "4.52.5",
@@ -3304,7 +3317,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
       "version": "4.52.5",
@@ -3317,7 +3331,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
       "version": "4.52.5",
@@ -3330,7 +3345,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
       "version": "4.52.5",
@@ -3343,7 +3359,8 @@
       "optional": true,
       "os": [
         "openharmony"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
       "version": "4.52.5",
@@ -3356,7 +3373,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
       "version": "4.52.5",
@@ -3369,7 +3387,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
       "version": "4.52.5",
@@ -3382,7 +3401,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
       "version": "4.52.5",
@@ -3395,7 +3415,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
@@ -3407,7 +3428,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
       "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/@storybook/addon-a11y": {
       "version": "10.0.4",
@@ -3990,7 +4012,6 @@
       "resolved": "https://registry.npmjs.org/@svgr/core/-/core-8.1.0.tgz",
       "integrity": "sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@babel/core": "^7.21.3",
         "@svgr/babel-preset": "8.1.0",
@@ -4375,7 +4396,6 @@
       "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.10.tgz",
       "integrity": "sha512-BKLss9Y8PQ9IUjPYQiv3/Zmlx92uxffUOX8ZZNoQlCIZBJPT5M+GOMQj7xislvVQ6l1BstBjcX0XB/aHfFYVNw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@tanstack/query-core": "5.90.10"
       },
@@ -4409,6 +4429,7 @@
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -4428,6 +4449,7 @@
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -4492,7 +4514,8 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -4622,7 +4645,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.2.tgz",
       "integrity": "sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA==",
       "devOptional": true,
-      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -4691,7 +4713,6 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.46.3.tgz",
       "integrity": "sha512-6m1I5RmHBGTnUGS113G04DMu3CpSdxCAU/UvtjNWL4Nuf3MW9tQhiJqRlHzChIkhy6kZSAQmc+I1bcGjE3yNKg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.46.3",
         "@typescript-eslint/types": "8.46.3",
@@ -5478,6 +5499,7 @@
       "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.7.tgz",
       "integrity": "sha512-orU1lsu4PxLEcDWfjVCNGIedOSF/YtZ+XMrd1PZb90E68khWCNzD8y1dtxtgd0hyBIQk8XggteKN/38VQLvzuw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@vitest/utils": "4.0.7",
         "pathe": "^2.0.3"
@@ -5491,6 +5513,7 @@
       "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.7.tgz",
       "integrity": "sha512-YY//yxqTmk29+/pK+Wi1UB4DUH3lSVgIm+M10rAJ74pOSMgT7rydMSc+vFuq9LjZLhFvVEXir8EcqMke3SVM6Q==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "tinyrainbow": "^3.0.3"
       },
@@ -5503,6 +5526,7 @@
       "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.7.tgz",
       "integrity": "sha512-HNrg9CM/Z4ZWB6RuExhuC6FPmLipiShKVMnT9JlQvfhwR47JatWLChA6mtZqVHqypE6p/z6ofcjbyWpM7YLxPQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@vitest/pretty-format": "4.0.7",
         "tinyrainbow": "^3.0.3"
@@ -5516,6 +5540,7 @@
       "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
       "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -5525,6 +5550,7 @@
       "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.7.tgz",
       "integrity": "sha512-xJL+Nkw0OjaUXXQf13B8iKK5pI9QVtN9uOtzNHYuG/o/B7fIEg0DQ+xOe0/RcqwDEI15rud1k7y5xznBKGUXAA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@vitest/pretty-format": "4.0.7",
         "magic-string": "^0.30.19",
@@ -5539,6 +5565,7 @@
       "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.7.tgz",
       "integrity": "sha512-YY//yxqTmk29+/pK+Wi1UB4DUH3lSVgIm+M10rAJ74pOSMgT7rydMSc+vFuq9LjZLhFvVEXir8EcqMke3SVM6Q==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "tinyrainbow": "^3.0.3"
       },
@@ -5551,6 +5578,7 @@
       "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
       "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -5756,7 +5784,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5817,7 +5844,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -6617,7 +6643,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.19",
         "caniuse-lite": "^1.0.30001751",
@@ -7464,6 +7489,7 @@
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -7519,7 +7545,8 @@
       "version": "0.5.16",
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/dom-converter": {
       "version": "0.2.0",
@@ -7898,7 +7925,6 @@
       "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
       "dev": true,
       "hasInstallScript": true,
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -7960,7 +7986,6 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.0.tgz",
       "integrity": "sha512-iy2GE3MHrYTL5lrCtMZ0X1KLEKKUjmK0kzwcnefhR66txcEmXZD2YWgR5GNdcEwkNx3a0siYkSvl0vIC+Svjmg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -8153,7 +8178,6 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz",
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -8443,6 +8467,7 @@
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.2.tgz",
       "integrity": "sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=12.0.0"
       }
@@ -10412,6 +10437,7 @@
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -11211,7 +11237,8 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/pathval": {
       "version": "2.0.1",
@@ -11337,7 +11364,6 @@
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.56.1.tgz",
       "integrity": "sha512-aFi5B0WovBHTEvpM3DzXTUaeN6eN0qWnTkKx4NQaH4Wvcmc153PdaY2UBdSYKaGYw+UyWXSVyxDUg5DoPEttjw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "playwright-core": "1.56.1"
       },
@@ -11399,7 +11425,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -11570,7 +11595,6 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -11674,6 +11698,7 @@
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -11688,6 +11713,7 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -11699,7 +11725,8 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/process": {
       "version": "0.11.10",
@@ -11836,7 +11863,6 @@
       "version": "19.2.0",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
       "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11907,7 +11933,6 @@
       "version": "19.2.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
       "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -11940,7 +11965,6 @@
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
       "integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -12570,7 +12594,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -12846,7 +12869,8 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/sirv": {
       "version": "3.0.2",
@@ -12918,7 +12942,8 @@
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/stackframe": {
       "version": "1.3.4",
@@ -12950,7 +12975,6 @@
       "resolved": "https://registry.npmjs.org/storybook/-/storybook-10.0.4.tgz",
       "integrity": "sha512-BRPz+TgWet6aV9xjQ2z3HeEELJX5BRxMUWqSPgyfemzrXa3slVL+4pLncTjlK1Qz1sEJORjy42qxdIKLXl4PwA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@storybook/global": "^5.0.0",
         "@storybook/icons": "^1.6.0",
@@ -13488,13 +13512,15 @@
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
       "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/tinyexec": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
       "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
@@ -13534,7 +13560,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -13697,7 +13722,6 @@
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
       "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=12.20"
       },
@@ -13784,7 +13808,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -14113,6 +14136,7 @@
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=12.0.0"
       },
@@ -14135,6 +14159,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
@@ -14235,6 +14260,7 @@
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.7.tgz",
       "integrity": "sha512-jGRG6HghnJDjljdjYIoVzX17S6uCVCBRFnsgdLGJ6CaxfPh8kzUKe/2n533y4O/aeZ/sIr7q7GbuEbeGDsWv4Q==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
         "@types/chai": "^5.2.2",
@@ -14252,6 +14278,7 @@
       "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.7.tgz",
       "integrity": "sha512-OsDwLS7WnpuNslOV6bJkXVYVV/6RSc4eeVxV7h9wxQPNxnjRvTTrIikfwCbMyl8XJmW6oOccBj2Q07YwZtQcCw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@vitest/spy": "4.0.7",
         "estree-walker": "^3.0.3",
@@ -14278,6 +14305,7 @@
       "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.7.tgz",
       "integrity": "sha512-YY//yxqTmk29+/pK+Wi1UB4DUH3lSVgIm+M10rAJ74pOSMgT7rydMSc+vFuq9LjZLhFvVEXir8EcqMke3SVM6Q==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "tinyrainbow": "^3.0.3"
       },
@@ -14290,6 +14318,7 @@
       "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.7.tgz",
       "integrity": "sha512-FW4X8hzIEn4z+HublB4hBF/FhCVaXfIHm8sUfvlznrcy1MQG7VooBgZPMtVCGZtHi0yl3KESaXTqsKh16d8cFg==",
       "dev": true,
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
@@ -14299,6 +14328,7 @@
       "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.7.tgz",
       "integrity": "sha512-HNrg9CM/Z4ZWB6RuExhuC6FPmLipiShKVMnT9JlQvfhwR47JatWLChA6mtZqVHqypE6p/z6ofcjbyWpM7YLxPQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@vitest/pretty-format": "4.0.7",
         "tinyrainbow": "^3.0.3"
@@ -14312,6 +14342,7 @@
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.0.tgz",
       "integrity": "sha512-aUTnJc/JipRzJrNADXVvpVqi6CO0dn3nx4EVPxijri+fj3LUUDyZQOgVeW54Ob3Y1Xh9Iz8f+CgaCl8v0mn9bA==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -14321,6 +14352,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -14333,6 +14365,7 @@
       "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
       "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -14361,7 +14394,6 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.102.1.tgz",
       "integrity": "sha512-7h/weGm9d/ywQ6qzJ+Xy+r9n/3qgp/thalBbpOi5i223dPXKi04IBtqPN9nTd+jBc7QKfvDbaBnFipYp4sJAUQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -14438,7 +14470,6 @@
       "resolved": "https://registry.npmjs.org/webpack-hot-middleware/-/webpack-hot-middleware-2.26.1.tgz",
       "integrity": "sha512-khZGfAeJx6I8K9zKohEWWYN6KDlVw2DHownoe+6Vtwj1LP9WFgegXnVMSkZ/dBEBtXFwrkkydsaPFlB7f8wU2A==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "ansi-html-community": "0.0.8",
         "html-entities": "^2.1.0",
@@ -14599,6 +14630,7 @@
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
       "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "siginfo": "^2.0.0",
         "stackback": "0.0.2"
@@ -14678,7 +14710,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.12.tgz",
       "integrity": "sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ==",
       "dev": true,
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/features/mypage/api/index.ts
+++ b/src/features/mypage/api/index.ts
@@ -1,0 +1,24 @@
+import { clientProxyInstance } from "@/services/instance/client";
+
+interface ChangePasswordParameters {
+  teamId: string;
+  password: string;
+  passwordConfirmation: string;
+}
+
+interface ChangePasswordResponse {
+  message: string;
+}
+
+export async function patchChangePassword(
+  params: ChangePasswordParameters
+): Promise<ChangePasswordResponse> {
+  const response = await clientProxyInstance.patch<ChangePasswordResponse>(
+    `/${params.teamId}/user/password`,
+    {
+      password: params.password,
+      passwordConfirmation: params.passwordConfirmation,
+    }
+  );
+  return response.data;
+}

--- a/src/pages/api/[teamId]/user/password.ts
+++ b/src/pages/api/[teamId]/user/password.ts
@@ -1,0 +1,41 @@
+import { serverApiInstance } from "@/services/instance/server";
+import { withAxiosErrorResponse } from "@/services/with-axios-error-response";
+import { NextApiRequest, NextApiResponse } from "next";
+
+interface Response {
+  message: string;
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (req.method !== "PATCH") {
+    res.status(405).json({ message: "Method Not Allowed" });
+    return;
+  }
+
+  const { teamId } = req.query;
+
+  if (!teamId || typeof teamId !== "string") {
+    res.status(400).json({ message: "teamId is required" });
+    return;
+  }
+
+  serverApiInstance.defaults.headers.common.Authorization =
+    req.headers.authorization;
+
+  withAxiosErrorResponse(
+    res,
+    async () => {
+      const response = await serverApiInstance.patch<Response>(
+        `/user/password`,
+        req.body
+      );
+      res.status(200).json(response.data);
+    },
+    () => {
+      delete serverApiInstance.defaults.headers.common.Authorization;
+    }
+  );
+}

--- a/src/pages/mypage/index.tsx
+++ b/src/pages/mypage/index.tsx
@@ -1,64 +1,35 @@
 import { Button } from "@/components/button";
 import Icon from "@/components/icon";
 import { AvatarInput } from "@/components/input";
-import { Alert } from "@/components/modal";
+import { Alert, ErrorAlert } from "@/components/modal";
 import InputLabel from "@/features/login/components/InputLabel";
+import PasswordVisible from "@/features/login/components/PasswordVisible";
+import { patchChangePassword } from "@/features/mypage/api";
+import { useAuthStore } from "@/stores/auth-store";
+import {
+  validatePassword,
+  validatePasswordConfirm,
+} from "@/utils/login-validator";
+import { isAxiosError } from "axios";
 import { overlay } from "overlay-kit";
 import { useState } from "react";
 
 export default function MyPage() {
-  const [name, setName] = useState("찬민테스트");
-  const [email] = useState("chanmin@text.com");
+  const user = useAuthStore((state) => state.user);
+  const [name, setName] = useState(user?.nickname || "");
+  const email = user?.email || "";
 
   const handleChangePasswordClick = () => {
+    if (!user?.teamId) {
+      return;
+    }
     overlay.open(
       ({ isOpen, close, unmount }) => (
-        <Alert
+        <ChangePasswordModal
           isOpen={isOpen}
           onClose={close}
           onExit={unmount}
-          title="비밀번호 변경하기"
-          content={
-            <div className="flex flex-col gap-10">
-              <div className="h-16">
-                <InputLabel
-                  label="새 비밀번호"
-                  id="newPassword"
-                  type="password"
-                  placeholder="새 비밀번호를 입력해주세요."
-                  size="large"
-                />
-              </div>
-
-              <div className="h-20">
-                <InputLabel
-                  label="새 비밀번호 확인"
-                  id="confirmNewPassword"
-                  type="password"
-                  placeholder="다시 한 번 입력해주세요."
-                  size="large"
-                />
-              </div>
-            </div>
-          }
-          actions={[
-            <Button
-              key="close"
-              title="닫기"
-              variant="outlinedPrimary"
-              size="large"
-              isFullWidth={true}
-              onClick={close}
-            />,
-            <Button
-              key="change"
-              title="변경하기"
-              variant="primary"
-              size="large"
-              isFullWidth={true}
-              onClick={close}
-            />,
-          ]}
+          teamId={user.teamId}
         />
       ),
       { overlayId: "change-password-alert" }
@@ -131,7 +102,6 @@ export default function MyPage() {
             label="이메일"
             id="email"
             type="email"
-            placeholder="이메일을 입력해주세요."
             size="large"
             value={email}
             disabled
@@ -167,5 +137,236 @@ export default function MyPage() {
         </div>
       </div>
     </div>
+  );
+}
+
+interface ChangePasswordModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onExit: () => void;
+  teamId: string;
+}
+
+function ChangePasswordModal({
+  isOpen,
+  onClose,
+  onExit,
+  teamId,
+}: ChangePasswordModalProps) {
+  const [newPassword, setNewPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [isPasswordVisible, setIsPasswordVisible] = useState(false);
+  const [newPasswordError, setNewPasswordError] = useState<
+    string | undefined
+  >();
+  const [confirmPasswordError, setConfirmPasswordError] = useState<
+    string | undefined
+  >();
+  const [isLoading, setIsLoading] = useState(false);
+
+  const validateForm = () => {
+    const passwordResult = validatePassword(newPassword);
+    const confirmResult = validatePasswordConfirm(newPassword, confirmPassword);
+
+    setNewPasswordError(
+      passwordResult.valid ? undefined : passwordResult.reason
+    );
+    setConfirmPasswordError(
+      confirmResult.valid ? undefined : confirmResult.reason
+    );
+
+    return passwordResult.valid && confirmResult.valid;
+  };
+
+  const handleNewPasswordBlur = () => {
+    const result = validatePassword(newPassword);
+    setNewPasswordError(result.valid ? undefined : result.reason);
+  };
+
+  const handleConfirmPasswordBlur = () => {
+    const result = validatePasswordConfirm(newPassword, confirmPassword);
+    setConfirmPasswordError(result.valid ? undefined : result.reason);
+  };
+
+  const handleChangeClick = async () => {
+    if (!validateForm()) {
+      return;
+    }
+
+    setIsLoading(true);
+    try {
+      await patchChangePassword({
+        teamId,
+        password: newPassword,
+        passwordConfirmation: confirmPassword,
+      });
+
+      overlay.close("change-password-alert");
+      overlay.unmount("change-password-alert");
+      onClose();
+
+      overlay.open(
+        ({ isOpen, close, unmount }) => (
+          <Alert
+            isOpen={isOpen}
+            onClose={close}
+            onExit={unmount}
+            title="비밀번호가 변경되었습니다"
+            actions={[
+              <Button
+                key="confirm"
+                title="확인"
+                variant="primary"
+                size="large"
+                isFullWidth={true}
+                onClick={close}
+              />,
+            ]}
+          />
+        ),
+        { overlayId: "password-change-success-alert" }
+      );
+    } catch (error) {
+      overlay.close("change-password-alert");
+      overlay.unmount("change-password-alert");
+
+      if (isAxiosError(error) && error.response?.status === 400) {
+        const errorData = error.response.data;
+        const errorMessage =
+          typeof errorData?.message === "string"
+            ? errorData.message
+            : errorData?.message?.message || "";
+
+        const isSamePasswordError =
+          /이미 사용중인 비밀번호|동일한 비밀번호/i.test(errorMessage);
+
+        if (isSamePasswordError) {
+          overlay.open(
+            ({ isOpen, close, unmount }) => (
+              <ErrorAlert
+                isOpen={isOpen}
+                onClose={close}
+                onExit={unmount}
+                title="비밀번호 변경이 실패하였습니다."
+                error={new Error("이미 사용중인 비밀번호입니다.")}
+              />
+            ),
+            { overlayId: "password-change-error-alert" }
+          );
+        } else {
+          overlay.open(
+            ({ isOpen, close, unmount }) => (
+              <ErrorAlert
+                isOpen={isOpen}
+                onClose={close}
+                onExit={unmount}
+                title="비밀번호 변경이 실패하였습니다."
+                error={new Error("다시 시도해주세요.")}
+              />
+            ),
+            { overlayId: "password-change-error-alert" }
+          );
+        }
+      } else {
+        overlay.open(
+          ({ isOpen, close, unmount }) => (
+            <ErrorAlert
+              isOpen={isOpen}
+              onClose={close}
+              onExit={unmount}
+              title="비밀번호 변경이 실패하였습니다."
+              error={new Error("다시 시도해주세요.")}
+            />
+          ),
+          { overlayId: "password-change-error-alert" }
+        );
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const isFormValid = () => {
+    const passwordResult = validatePassword(newPassword);
+    const confirmResult = validatePasswordConfirm(newPassword, confirmPassword);
+    return passwordResult.valid && confirmResult.valid;
+  };
+
+  return (
+    <Alert
+      isOpen={isOpen}
+      onClose={onClose}
+      onExit={onExit}
+      title="비밀번호 변경하기"
+      content={
+        <div className="flex flex-col gap-20">
+          <div className={newPasswordError ? "h-10" : "h-6"}>
+            <InputLabel
+              label="새 비밀번호"
+              id="newPassword"
+              type={isPasswordVisible ? "text" : "password"}
+              placeholder="새 비밀번호를 입력해주세요."
+              size="large"
+              value={newPassword}
+              onChange={(event) => {
+                setNewPassword(event.target.value);
+                setNewPasswordError(undefined);
+              }}
+              onBlur={handleNewPasswordBlur}
+              errorMessage={newPasswordError}
+              trailing={
+                <PasswordVisible
+                  isVisible={isPasswordVisible}
+                  onToggle={() => setIsPasswordVisible(!isPasswordVisible)}
+                />
+              }
+            />
+          </div>
+
+          <div className={confirmPasswordError ? "mb-16 h-10" : "mb-16 h-6"}>
+            <InputLabel
+              label="새 비밀번호 확인"
+              id="confirmNewPassword"
+              type={isPasswordVisible ? "text" : "password"}
+              placeholder="다시 한 번 입력해주세요."
+              size="large"
+              value={confirmPassword}
+              onChange={(event) => {
+                setConfirmPassword(event.target.value);
+                setConfirmPasswordError(undefined);
+              }}
+              onBlur={handleConfirmPasswordBlur}
+              errorMessage={confirmPasswordError}
+              trailing={
+                <PasswordVisible
+                  isVisible={isPasswordVisible}
+                  onToggle={() => setIsPasswordVisible(!isPasswordVisible)}
+                />
+              }
+            />
+          </div>
+        </div>
+      }
+      actions={[
+        <Button
+          key="close"
+          title="닫기"
+          variant="outlinedPrimary"
+          size="large"
+          isFullWidth={true}
+          onClick={onClose}
+          disabled={isLoading}
+        />,
+        <Button
+          key="change"
+          title="변경하기"
+          variant="primary"
+          size="large"
+          isFullWidth={true}
+          onClick={handleChangeClick}
+          disabled={!isFormValid() || isLoading}
+        />,
+      ]}
+    />
   );
 }

--- a/src/pages/mypage/index.tsx
+++ b/src/pages/mypage/index.tsx
@@ -10,7 +10,6 @@ import {
   validatePassword,
   validatePasswordConfirm,
 } from "@/utils/login-validator";
-import { isAxiosError } from "axios";
 import { overlay } from "overlay-kit";
 import { useState } from "react";
 
@@ -200,11 +199,6 @@ function ChangePasswordModal({
         password: newPassword,
         passwordConfirmation: confirmPassword,
       });
-
-      overlay.close("change-password-alert");
-      overlay.unmount("change-password-alert");
-      onClose();
-
       overlay.open(
         ({ isOpen, close, unmount }) => (
           <Alert
@@ -226,63 +220,22 @@ function ChangePasswordModal({
         ),
         { overlayId: "password-change-success-alert" }
       );
-    } catch (error) {
-      overlay.close("change-password-alert");
-      overlay.unmount("change-password-alert");
-
-      if (isAxiosError(error) && error.response?.status === 400) {
-        const errorData = error.response.data;
-        const errorMessage =
-          typeof errorData?.message === "string"
-            ? errorData.message
-            : errorData?.message?.message || "";
-
-        const isSamePasswordError =
-          /이미 사용중인 비밀번호|동일한 비밀번호/i.test(errorMessage);
-
-        if (isSamePasswordError) {
-          overlay.open(
-            ({ isOpen, close, unmount }) => (
-              <ErrorAlert
-                isOpen={isOpen}
-                onClose={close}
-                onExit={unmount}
-                title="비밀번호 변경이 실패하였습니다."
-                error={new Error("이미 사용중인 비밀번호입니다.")}
-              />
-            ),
-            { overlayId: "password-change-error-alert" }
-          );
-        } else {
-          overlay.open(
-            ({ isOpen, close, unmount }) => (
-              <ErrorAlert
-                isOpen={isOpen}
-                onClose={close}
-                onExit={unmount}
-                title="비밀번호 변경이 실패하였습니다."
-                error={new Error("다시 시도해주세요.")}
-              />
-            ),
-            { overlayId: "password-change-error-alert" }
-          );
-        }
-      } else {
-        overlay.open(
-          ({ isOpen, close, unmount }) => (
-            <ErrorAlert
-              isOpen={isOpen}
-              onClose={close}
-              onExit={unmount}
-              title="비밀번호 변경이 실패하였습니다."
-              error={new Error("다시 시도해주세요.")}
-            />
-          ),
-          { overlayId: "password-change-error-alert" }
-        );
-      }
+    } catch {
+      overlay.open(
+        ({ isOpen, close, unmount }) => (
+          <ErrorAlert
+            isOpen={isOpen}
+            onClose={close}
+            onExit={unmount}
+            title="비밀번호 변경이 실패하였습니다."
+            error={new Error("다시 시도해주세요.")}
+          />
+        ),
+        { overlayId: "password-change-error-alert" }
+      );
     } finally {
       setIsLoading(false);
+      onClose();
     }
   };
 

--- a/src/pages/signup/index.tsx
+++ b/src/pages/signup/index.tsx
@@ -5,6 +5,7 @@ import { postSignUp } from "@/features/auth/apis";
 import InputLabel from "@/features/login/components/InputLabel";
 import PasswordVisible from "@/features/login/components/PasswordVisible";
 import { useAuthStore } from "@/stores/auth-store";
+import { SignUpErrorResponse } from "@/types/signup";
 import {
   validateEmail,
   validateName,
@@ -16,7 +17,7 @@ import { overlay } from "overlay-kit";
 import { FormEvent, useState } from "react";
 
 export default function SignUpPage() {
-  const [isPasswordVisible, setIsPasswordVisible] = useState(false);
+  const [isPasswordVisible, setPasswordVisible] = useState(false);
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
@@ -27,8 +28,9 @@ export default function SignUpPage() {
   const [confirmedPasswordError, setConfirmedPasswordError] = useState<
     string | undefined
   >();
-  const [isEmailErrorModalOpen, setIsEmailErrorModalOpen] = useState(false);
-  const [isSuccessModalOpen, setIsSuccessModalOpen] = useState(false);
+  const [isEmailErrorModalOpen, setEmailErrorModalOpen] = useState(false);
+  const [isGeneralErrorModalOpen, setGeneralErrorModalOpen] = useState(false);
+  const [isSuccessModalOpen, setSuccessModalOpen] = useState(false);
 
   const validateTotalForm = () => {
     const nameResult = validateName(name);
@@ -102,6 +104,38 @@ export default function SignUpPage() {
 
   const isFormValid = validateTotalForm().isValid;
 
+  const openGeneralErrorAlert = () => {
+    if (
+      isSuccessModalOpen ||
+      isGeneralErrorModalOpen ||
+      isEmailErrorModalOpen
+    ) {
+      return;
+    }
+
+    overlay.close("signup-success-alert");
+    overlay.unmount("signup-success-alert");
+    overlay.close("email-duplicate-error-alert");
+    overlay.unmount("email-duplicate-error-alert");
+
+    setGeneralErrorModalOpen(true);
+    overlay.open(
+      ({ isOpen, close, unmount }) => (
+        <ErrorAlert
+          isOpen={isOpen}
+          onClose={close}
+          onExit={() => {
+            setGeneralErrorModalOpen(false);
+            unmount();
+          }}
+          title="회원가입에 실패했습니다."
+          error={new Error("다시 시도해주세요.")}
+        />
+      ),
+      { overlayId: "signup-general-error-alert" }
+    );
+  };
+
   const handleSignUpButtonClick = async () => {
     const validation = validateTotalForm();
 
@@ -124,15 +158,15 @@ export default function SignUpPage() {
 
       overlay.close("email-duplicate-error-alert");
       overlay.unmount("email-duplicate-error-alert");
-      setIsEmailErrorModalOpen(false);
-      setIsSuccessModalOpen(true);
+      setEmailErrorModalOpen(false);
+      setSuccessModalOpen(true);
       overlay.open(
         ({ isOpen, close, unmount }) => (
           <Alert
             isOpen={isOpen}
             onClose={() => {}}
             onExit={() => {
-              setIsSuccessModalOpen(false);
+              setSuccessModalOpen(false);
               unmount();
             }}
             allowsBackgroundDismiss={false}
@@ -160,40 +194,39 @@ export default function SignUpPage() {
         { overlayId: "signup-success-alert" }
       );
     } catch (error) {
-      const axiosError = error as {
-        response?: {
-          status?: number;
-          data?: {
-            message?: string;
-            details?: {
-              email?: { message?: string };
-            };
-            email?: string | { message?: string };
-          };
-        };
-      };
+      const axiosError = error as SignUpErrorResponse;
 
       if (axiosError?.response?.status === 400) {
         const errorData = axiosError.response.data;
-        const hasEmailError =
-          errorData?.details?.email ||
-          errorData?.email ||
-          /이메일|email/i.test(errorData?.message || "");
+        const detailsEntries = Object.entries(errorData?.details ?? {});
+        const emailDetailEntry = detailsEntries.find(([key]) =>
+          key.toLowerCase().includes("email")
+        );
+        const emailDetail = emailDetailEntry?.[1] as
+          | { message?: string }
+          | undefined;
+        const emailErrorMessage =
+          (typeof errorData?.email === "string"
+            ? errorData.email
+            : errorData?.email?.message) || emailDetail?.message;
 
-        if (hasEmailError && !isSuccessModalOpen && !isEmailErrorModalOpen) {
-          overlay.close("signup-success-alert");
-          overlay.unmount("signup-success-alert");
-          overlay.close("email-duplicate-error-alert");
-          overlay.unmount("email-duplicate-error-alert");
+        const isDuplicateEmailError = /중복|이미 사용중인 이메일/i.test(
+          emailErrorMessage || ""
+        );
 
-          setIsEmailErrorModalOpen(true);
+        if (
+          isDuplicateEmailError &&
+          !isSuccessModalOpen &&
+          !isEmailErrorModalOpen
+        ) {
+          setEmailErrorModalOpen(true);
           overlay.open(
             ({ isOpen, close, unmount }) => (
               <ErrorAlert
                 isOpen={isOpen}
                 onClose={close}
                 onExit={() => {
-                  setIsEmailErrorModalOpen(false);
+                  setEmailErrorModalOpen(false);
                   unmount();
                 }}
                 title="이미 사용중인 이메일입니다."
@@ -203,13 +236,10 @@ export default function SignUpPage() {
             { overlayId: "email-duplicate-error-alert" }
           );
         } else {
-          console.error(
-            "회원가입 에러:",
-            errorData?.message || "회원가입에 실패했습니다."
-          );
+          openGeneralErrorAlert();
         }
       } else {
-        console.error("회원가입 에러:", error);
+        openGeneralErrorAlert();
       }
     }
   };
@@ -273,7 +303,7 @@ export default function SignUpPage() {
                   trailing={
                     <PasswordVisible
                       isVisible={isPasswordVisible}
-                      onToggle={() => setIsPasswordVisible(!isPasswordVisible)}
+                      onToggle={() => setPasswordVisible(!isPasswordVisible)}
                     />
                   }
                 />
@@ -295,7 +325,7 @@ export default function SignUpPage() {
                   trailing={
                     <PasswordVisible
                       isVisible={isPasswordVisible}
-                      onToggle={() => setIsPasswordVisible(!isPasswordVisible)}
+                      onToggle={() => setPasswordVisible(!isPasswordVisible)}
                     />
                   }
                 />

--- a/src/pages/signup/index.tsx
+++ b/src/pages/signup/index.tsx
@@ -1,5 +1,7 @@
 import KakaotalkIcon from "@/assets/icons/ic-kakaotalk.svg";
 import { Button } from "@/components/button";
+import { Alert } from "@/components/modal";
+import { postSignUp } from "@/features/auth/apis";
 import InputLabel from "@/features/login/components/InputLabel";
 import PasswordVisible from "@/features/login/components/PasswordVisible";
 import {
@@ -8,12 +10,12 @@ import {
   validatePassword,
   validatePasswordConfirm,
 } from "@/utils/login-validator";
+import { useRouter } from "next/router";
+import { overlay } from "overlay-kit";
 import { FormEvent, useState } from "react";
 
 export default function SignUpPage() {
   const [isPasswordVisible, setIsPasswordVisible] = useState(false);
-  const [isConfirmPasswordVisible, setIsConfirmPasswordVisible] =
-    useState(false);
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
@@ -92,9 +94,11 @@ export default function SignUpPage() {
     validateBlurField("confirmedPassword");
   };
 
+  const router = useRouter();
+
   const isFormValid = validateTotalForm().isValid;
 
-  const handleSignUpButtonClick = () => {
+  const handleSignUpButtonClick = async () => {
     const validation = validateTotalForm();
 
     setNameError(validation.errors.nameError);
@@ -104,6 +108,74 @@ export default function SignUpPage() {
 
     if (!validation.isValid) {
       return;
+    }
+
+    try {
+      await postSignUp({
+        email,
+        nickname: name,
+        password,
+        passwordConfirmation: confirmedPassword,
+      });
+
+      overlay.open(
+        ({ isOpen, close, unmount }) => (
+          <Alert
+            isOpen={isOpen}
+            onClose={() => {}}
+            onExit={unmount}
+            allowsBackgroundDismiss={false}
+            showsCloseButton={false}
+            title="회원가입이 완료되었습니다!"
+            actions={[
+              <Button
+                key="move"
+                title="로그인하기"
+                variant="primary"
+                size="large"
+                isFullWidth={true}
+                onClick={() => {
+                  close();
+                  router.push("/login");
+                }}
+              />,
+            ]}
+          />
+        ),
+        { overlayId: "signup-success-alert" }
+      );
+    } catch (error) {
+      const axiosError = error as {
+        response?: {
+          status?: number;
+          data?: {
+            message?: string;
+            details?: {
+              email?: { message?: string };
+            };
+            email?: string | { message?: string };
+          };
+        };
+      };
+
+      if (axiosError?.response?.status === 400) {
+        const errorData = axiosError.response.data;
+        const hasEmailError =
+          errorData?.details?.email ||
+          errorData?.email ||
+          /이메일|email/i.test(errorData?.message || "");
+
+        if (hasEmailError) {
+          setEmailError("이미 사용중인 이메일입니다.");
+        } else {
+          console.error(
+            "회원가입 에러:",
+            errorData?.message || "회원가입에 실패했습니다."
+          );
+        }
+      } else {
+        console.error("회원가입 에러:", error);
+      }
     }
   };
 
@@ -178,7 +250,7 @@ export default function SignUpPage() {
                 <InputLabel
                   label="비밀번호 확인"
                   id="confirmPassword"
-                  type={isConfirmPasswordVisible ? "text" : "password"}
+                  type={isPasswordVisible ? "text" : "password"}
                   placeholder="비밀번호를 다시 한 번 입력해주세요."
                   size="large"
                   value={confirmedPassword}
@@ -187,10 +259,8 @@ export default function SignUpPage() {
                   errorMessage={confirmedPasswordError}
                   trailing={
                     <PasswordVisible
-                      isVisible={isConfirmPasswordVisible}
-                      onToggle={() =>
-                        setIsConfirmPasswordVisible(!isConfirmPasswordVisible)
-                      }
+                      isVisible={isPasswordVisible}
+                      onToggle={() => setIsPasswordVisible(!isPasswordVisible)}
                     />
                   }
                 />

--- a/src/pages/signup/index.tsx
+++ b/src/pages/signup/index.tsx
@@ -1,9 +1,10 @@
 import KakaotalkIcon from "@/assets/icons/ic-kakaotalk.svg";
 import { Button } from "@/components/button";
-import { Alert } from "@/components/modal";
+import { Alert, ErrorAlert } from "@/components/modal";
 import { postSignUp } from "@/features/auth/apis";
 import InputLabel from "@/features/login/components/InputLabel";
 import PasswordVisible from "@/features/login/components/PasswordVisible";
+import { useAuthStore } from "@/stores/auth-store";
 import {
   validateEmail,
   validateName,
@@ -26,6 +27,8 @@ export default function SignUpPage() {
   const [confirmedPasswordError, setConfirmedPasswordError] = useState<
     string | undefined
   >();
+  const [isEmailErrorModalOpen, setIsEmailErrorModalOpen] = useState(false);
+  const [isSuccessModalOpen, setIsSuccessModalOpen] = useState(false);
 
   const validateTotalForm = () => {
     const nameResult = validateName(name);
@@ -95,6 +98,7 @@ export default function SignUpPage() {
   };
 
   const router = useRouter();
+  const login = useAuthStore((state) => state.logIn);
 
   const isFormValid = validateTotalForm().isValid;
 
@@ -111,32 +115,43 @@ export default function SignUpPage() {
     }
 
     try {
-      await postSignUp({
+      const response = await postSignUp({
         email,
         nickname: name,
         password,
         passwordConfirmation: confirmedPassword,
       });
 
+      overlay.close("email-duplicate-error-alert");
+      overlay.unmount("email-duplicate-error-alert");
+      setIsEmailErrorModalOpen(false);
+      setIsSuccessModalOpen(true);
       overlay.open(
         ({ isOpen, close, unmount }) => (
           <Alert
             isOpen={isOpen}
             onClose={() => {}}
-            onExit={unmount}
+            onExit={() => {
+              setIsSuccessModalOpen(false);
+              unmount();
+            }}
             allowsBackgroundDismiss={false}
             showsCloseButton={false}
             title="회원가입이 완료되었습니다!"
             actions={[
               <Button
                 key="move"
-                title="로그인하기"
+                title="팀 페이지로 이동"
                 variant="primary"
                 size="large"
                 isFullWidth={true}
                 onClick={() => {
+                  login({
+                    accessToken: response.accessToken,
+                    user: response.user,
+                  });
                   close();
-                  router.push("/login");
+                  router.push("/dashboard");
                 }}
               />,
             ]}
@@ -165,8 +180,28 @@ export default function SignUpPage() {
           errorData?.email ||
           /이메일|email/i.test(errorData?.message || "");
 
-        if (hasEmailError) {
-          setEmailError("이미 사용중인 이메일입니다.");
+        if (hasEmailError && !isSuccessModalOpen && !isEmailErrorModalOpen) {
+          overlay.close("signup-success-alert");
+          overlay.unmount("signup-success-alert");
+          overlay.close("email-duplicate-error-alert");
+          overlay.unmount("email-duplicate-error-alert");
+
+          setIsEmailErrorModalOpen(true);
+          overlay.open(
+            ({ isOpen, close, unmount }) => (
+              <ErrorAlert
+                isOpen={isOpen}
+                onClose={close}
+                onExit={() => {
+                  setIsEmailErrorModalOpen(false);
+                  unmount();
+                }}
+                title="이미 사용중인 이메일입니다."
+                error={new Error("다른 이메일을 입력해주세요.")}
+              />
+            ),
+            { overlayId: "email-duplicate-error-alert" }
+          );
         } else {
           console.error(
             "회원가입 에러:",

--- a/src/pages/signup/index.tsx
+++ b/src/pages/signup/index.tsx
@@ -113,11 +113,6 @@ export default function SignUpPage() {
       return;
     }
 
-    overlay.close("signup-success-alert");
-    overlay.unmount("signup-success-alert");
-    overlay.close("email-duplicate-error-alert");
-    overlay.unmount("email-duplicate-error-alert");
-
     setGeneralErrorModalOpen(true);
     overlay.open(
       ({ isOpen, close, unmount }) => (
@@ -156,8 +151,6 @@ export default function SignUpPage() {
         passwordConfirmation: confirmedPassword,
       });
 
-      overlay.close("email-duplicate-error-alert");
-      overlay.unmount("email-duplicate-error-alert");
       setEmailErrorModalOpen(false);
       setSuccessModalOpen(true);
       overlay.open(
@@ -340,7 +333,6 @@ export default function SignUpPage() {
               size="large"
               isFullWidth={true}
               disabled={!isFormValid}
-              onClick={handleSignUpButtonClick}
             />
           </div>
         </form>

--- a/src/services/instance/client.ts
+++ b/src/services/instance/client.ts
@@ -18,3 +18,9 @@ clientApiInstance.interceptors.response.use(
   clientResponseInterceptor,
   clientResponseErrorInterceptor
 );
+
+clientProxyInstance.interceptors.request.use(clientRequestInterceptor);
+clientProxyInstance.interceptors.response.use(
+  clientResponseInterceptor,
+  clientResponseErrorInterceptor
+);

--- a/src/types/signup.ts
+++ b/src/types/signup.ts
@@ -1,0 +1,12 @@
+export type SignUpErrorResponseData = {
+  message?: string;
+  details?: Record<string, { message?: string; value?: string }>;
+  email?: string | { message?: string };
+};
+
+export type SignUpErrorResponse = {
+  response?: {
+    status?: number;
+    data?: SignUpErrorResponseData;
+  };
+};


### PR DESCRIPTION
## 📝 요약
- 계정 설정 페이지에서 비밀번호 변경 모달로 현재 비밀번호를 변경하는 기능 구현

## ✨ 구현 내용
- 계정 설정 페이지에서 비밀번호 변경 버튼을 클릭하여 비밀번호 변경 모달에서 변경할 비밀번호를 입력한 다음 변경하기를 누르면 비밀번호가 재설정됩니다

### 🎯 실제 결과


![로그인 - 변경페이지](https://github.com/user-attachments/assets/86de4bca-3fa1-4aef-a6bb-7ef8e51979f0)

![비밀번호 변경함](https://github.com/user-attachments/assets/0a506e46-3a11-41ed-8388-eb273aeebf8c)

![비밀번호 변경된걸로 로그인](https://github.com/user-attachments/assets/21cce2f9-c49c-4099-b775-c0cf7bd71f7a)


### 📸 참고 자료
시나리오 입니다
chanmin@test64.com 이메일의 초기 비밀번호 cksals123!
계성 설정 페이지에서 비밀번호를 cksals123@로 변경
로그아웃 후 chanmin@test64.com에서 
cksals123!로 로그인 시도 -> 로그인 실패
cksals123@로 로그인 시도 -> 로그인 성공

---

## 💬 리뷰어 참고 사항 및 알게된 점


## ✅ 체크리스트
- [x] 주요 기능 테스트 완료
- [x] 빌드 및 실행 확인
- [x] 커밋 메시지 컨벤션 및 작업 내용 일치 확인