### PR TITLE
[#136] 팀 페이지 할 일 완료 클릭할 때 리스트 페이지로 이동하는 문제 수정

### DIFF
--- a/src/features/group/components/TeamPageTaskListCard.tsx
+++ b/src/features/group/components/TeamPageTaskListCard.tsx
@@ -9,7 +9,7 @@ import { useResponsive } from "@/hooks/use-responsive";
 import { Task, TaskList } from "@/types/task";
 import { isEmpty } from "@/utils/array-sugar";
 import { overlay } from "overlay-kit";
-import { Attributes } from "react";
+import { Attributes, MouseEvent } from "react";
 import { groupsQueryKey } from "../query/query-key";
 import { useTeamContext } from "./TeamProvider";
 
@@ -147,7 +147,8 @@ function TaskCheckbox({ key, groupId, taskList, task }: TaskCheckboxProps) {
     taskListId: taskList.id,
   });
 
-  const handleToggle = () => {
+  const handleToggle = (event: MouseEvent) => {
+    event.stopPropagation();
     patchMutation.mutate(
       { taskId: task.id, done: !isTaskDone(task) },
       {

--- a/src/features/group/components/TeamPageTaskListCard.tsx
+++ b/src/features/group/components/TeamPageTaskListCard.tsx
@@ -8,6 +8,7 @@ import { useTaskListMutation } from "@/features/tasklist/query";
 import { useResponsive } from "@/hooks/use-responsive";
 import { Task, TaskList } from "@/types/task";
 import { isEmpty } from "@/utils/array-sugar";
+import { useRouter } from "next/router";
 import { overlay } from "overlay-kit";
 import { Attributes, MouseEvent } from "react";
 import { groupsQueryKey } from "../query/query-key";
@@ -24,6 +25,11 @@ export default function TeamPageTaskListCard({ key, taskList, done }: Props) {
   const tasks = taskList.tasks;
   const doneTasks = tasks.filter(isTaskDone);
   const { deleteMutation, patchMutation } = useTaskListMutation();
+  const router = useRouter();
+
+  const handleCardClick = () => {
+    router.push(`/${group.id}/tasklist?id=${taskList.id}`);
+  };
 
   const handleEditClick = () => {
     const handleSubmit = (newName: string) => {
@@ -94,7 +100,8 @@ export default function TeamPageTaskListCard({ key, taskList, done }: Props) {
   return (
     <div
       key={key}
-      className="flex flex-col gap-4 rounded-xl border border-border-primary bg-background-primary py-4 pr-4 pl-5"
+      className="flex cursor-pointer flex-col gap-4 rounded-xl border border-border-primary bg-background-primary py-4 pr-4 pl-5"
+      onClick={handleCardClick}
     >
       <div className="flex items-center justify-between">
         <h3 className="text-lg-s text-text-primary">{taskList.name}</h3>

--- a/src/features/group/components/TeamPageTasksBoard.tsx
+++ b/src/features/group/components/TeamPageTasksBoard.tsx
@@ -1,7 +1,6 @@
 import { isTaskListDone } from "@/features/tasklist/utils";
 import { useResponsive } from "@/hooks/use-responsive";
 import { TaskList } from "@/types/task";
-import Link from "next/link";
 import { PropsWithChildren } from "react";
 import TeamPageMembersList from "./TeamPageMembersList";
 import TeamPageTaskListCard from "./TeamPageTaskListCard";
@@ -18,7 +17,7 @@ export default function TeamPageTasksBoard({ taskLists }: Props) {
   return (
     <div className="flex items-start gap-8">
       {taskLists.length > 0 ? (
-        <TaskListsBoard groupId={group.id} taskLists={taskLists} />
+        <TaskListsBoard taskLists={taskLists} />
       ) : (
         <EmptyTaskListsBoard isDesktop={isDesktop} />
       )}
@@ -49,13 +48,7 @@ function EmptyTaskListsBoard({ isDesktop }: { isDesktop: boolean }) {
   );
 }
 
-function TaskListsBoard({
-  groupId,
-  taskLists,
-}: {
-  groupId: number;
-  taskLists: TaskList[];
-}) {
+function TaskListsBoard({ taskLists }: { taskLists: TaskList[] }) {
   const doneLists = taskLists.filter(isTaskListDone);
   const doneIds = doneLists.map((taskList) => taskList.id);
 
@@ -83,9 +76,9 @@ function TaskListsBoard({
 
   return (
     <BoardSection>
-      <Column groupId={groupId} title="할 일" taskLists={toDoLists} />
-      <Column groupId={groupId} title="진행중" taskLists={inProgressLists} />
-      <Column groupId={groupId} title="완료" taskLists={doneLists} done />
+      <Column title="할 일" taskLists={toDoLists} />
+      <Column title="진행중" taskLists={inProgressLists} />
+      <Column title="완료" taskLists={doneLists} done />
     </BoardSection>
   );
 }
@@ -99,12 +92,10 @@ function BoardSection({ children }: PropsWithChildren) {
 }
 
 function Column({
-  groupId,
   taskLists,
   title,
   done = false,
 }: {
-  groupId: number;
   taskLists: TaskList[];
   title: string;
   done?: boolean;
@@ -112,7 +103,7 @@ function Column({
   return (
     <div className="flex w-full grow flex-col gap-3 desktop:gap-5">
       <ColumnHeader title={title} />
-      <ColumnBody groupId={groupId} taskLists={taskLists} done={done} />
+      <ColumnBody taskLists={taskLists} done={done} />
     </div>
   );
 }
@@ -126,20 +117,20 @@ function ColumnHeader({ title }: { title: string }) {
 }
 
 function ColumnBody({
-  groupId,
   taskLists,
   done,
 }: {
-  groupId: number;
   taskLists: TaskList[];
   done: boolean;
 }) {
   return (
     <div className="flex flex-col gap-2">
       {taskLists.map((taskList) => (
-        <Link href={`/${groupId}/tasklist?id=${taskList.id}`} key={taskList.id}>
-          <TeamPageTaskListCard taskList={taskList} done={done} />
-        </Link>
+        <TeamPageTaskListCard
+          key={taskList.id}
+          taskList={taskList}
+          done={done}
+        />
       ))}
     </div>
   );


### PR DESCRIPTION
## 📝 요약

- 팀 페이지의 `TaskList`에서 checkbox를 클릭하면 완료 처리됨과 동시에 리스트 페이지로 이동하는 문제를 수정합니다.

## ✨ 구현 내용

- Checkbox의 click event handler에서 `stopPropagation`을 호출해서 buggling을 방지합니다.
- 리스트 페이지로 이동할 때 `Link` 대신 click event handler에서 router를 사용하도록 변경합니다.

### 🎯 실제 결과

- Checkbox 또는 `...` 버튼을 클릭하면 페이지 이동 없이 해당 기능을 사용할 수 있습니다.

---

## ✅ 체크리스트
- [x] 주요 기능 테스트 완료
- [x] 빌드 및 실행 확인
- [x] 커밋 메시지 컨벤션 및 작업 내용 일치 확인