### PR TITLE
[#143] Sidebar의 팀 목록에 scroll이 활성화 되지 않아도 scrollbar가 표시되는 문제

### DIFF
--- a/src/components/gnb/common/UserGroupList.tsx
+++ b/src/components/gnb/common/UserGroupList.tsx
@@ -33,7 +33,7 @@ export default function UserGroupList({
         <Dropdown isOpen={isDropdownOpen} onClick={handleDropdownClick} />
       )}
       {(isMobile || isDropdownOpen) && (
-        <ul className="flex max-h-[220px] flex-col overflow-y-scroll tablet:max-h-[292px] tablet:gap-2">
+        <ul className="flex custom-scroll-bar max-h-[220px] flex-col overflow-y-auto tablet:max-h-[292px] tablet:gap-2">
           {groups.map((group) => (
             <li key={group.id}>
               <Link href={`/${group.id}`}>


### PR DESCRIPTION
## 📝 요약

- Sidebar의 팀 목록에 scroll이 활성화 되지 않아도 scrollbar가 표시되는 문제를 수정합니다.

## ✨ 구현 내용

- `overflow-y-scroll`을 `overflow-y-auto`로 변경합니다.
- Custom scrollbar style을 적용합니다.

### 🎯 실제 결과

<img width="258" height="339" alt="image" src="https://github.com/user-attachments/assets/e0d41ea4-53a6-4712-9671-7edcae6d3fcf" />

---

## ✅ 체크리스트
- [x] 주요 기능 테스트 완료
- [x] 빌드 및 실행 확인
- [x] 커밋 메시지 컨벤션 및 작업 내용 일치 확인