### PR TITLE
[#138] 회원탈퇴 기능 구현

### DIFF
--- a/src/features/mypage/api/index.ts
+++ b/src/features/mypage/api/index.ts
@@ -22,3 +22,20 @@ export async function patchChangePassword(
   );
   return response.data;
 }
+
+interface DeleteUserParameters {
+  teamId: string;
+}
+
+interface DeleteUserResponse {
+  message: string;
+}
+
+export async function deleteUser(
+  params: DeleteUserParameters
+): Promise<DeleteUserResponse> {
+  const response = await clientProxyInstance.delete<DeleteUserResponse>(
+    `/${params.teamId}/user/membershipwithdrawal`
+  );
+  return response.data;
+}

--- a/src/libs/ssr/with-auth.ts
+++ b/src/libs/ssr/with-auth.ts
@@ -1,6 +1,8 @@
 import { postRefreshToken } from "@/features/auth/apis";
+import { createExpiredCookie } from "@/features/auth/utils/cookie";
 import { GSSP_LOGIN_REDIRECT_RETURN } from "@/libs/ssr/gssp-return";
 import { DehydratedState } from "@tanstack/react-query";
+import { AxiosError } from "axios";
 import { GetServerSidePropsContext, GetServerSidePropsResult } from "next";
 import { JSX } from "react";
 import { useUpdateAccessToken } from "./use-update-access-token";
@@ -22,8 +24,18 @@ export function gsspWithAuth<Data>(
       return GSSP_LOGIN_REDIRECT_RETURN;
     }
 
-    const accessToken = await postRefreshToken(refreshToken, { ssr: true });
-    return getServerSidePropsFunc(context, accessToken);
+    try {
+      const accessToken = await postRefreshToken(refreshToken, { ssr: true });
+      return getServerSidePropsFunc(context, accessToken);
+    } catch (error) {
+      if (error instanceof AxiosError && error.response?.status === 400) {
+        const expiredCookie = createExpiredCookie({ name: "refreshToken" });
+        context.res.setHeader("Set-Cookie", expiredCookie);
+        return GSSP_LOGIN_REDIRECT_RETURN;
+      }
+
+      throw error;
+    }
   };
 }
 

--- a/src/pages/api/[teamId]/user/membershipwithdrawal.ts
+++ b/src/pages/api/[teamId]/user/membershipwithdrawal.ts
@@ -1,4 +1,4 @@
-import { createExpiredCookie } from "@/features/auth/utils/cookie";
+import signOutHandler from "@/pages/api/auth/signOut";
 import { serverApiInstance } from "@/services/instance/server";
 import { withAxiosErrorResponse } from "@/services/with-axios-error-response";
 import { NextApiRequest, NextApiResponse } from "next";
@@ -30,9 +30,11 @@ export default async function handler(
     res,
     async () => {
       const response = await serverApiInstance.delete<Response>(`/user`);
-      // 회원 탈퇴 성공 시 refreshToken 쿠키 삭제
-      const cookie = createExpiredCookie({ name: "refreshToken" });
-      res.setHeader("Set-Cookie", cookie);
+      const signOutReq = {
+        ...req,
+        method: "POST",
+      } as NextApiRequest;
+      await signOutHandler(signOutReq, res);
       res.status(200).json(response.data);
     },
     () => {

--- a/src/pages/api/[teamId]/user/membershipwithdrawal.ts
+++ b/src/pages/api/[teamId]/user/membershipwithdrawal.ts
@@ -1,0 +1,42 @@
+import { createExpiredCookie } from "@/features/auth/utils/cookie";
+import { serverApiInstance } from "@/services/instance/server";
+import { withAxiosErrorResponse } from "@/services/with-axios-error-response";
+import { NextApiRequest, NextApiResponse } from "next";
+
+interface Response {
+  message: string;
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (req.method !== "DELETE") {
+    res.status(405).json({ message: "Method Not Allowed" });
+    return;
+  }
+
+  const { teamId } = req.query;
+
+  if (!teamId || typeof teamId !== "string") {
+    res.status(400).json({ message: "teamId is required" });
+    return;
+  }
+
+  serverApiInstance.defaults.headers.common.Authorization =
+    req.headers.authorization;
+
+  withAxiosErrorResponse(
+    res,
+    async () => {
+      const response = await serverApiInstance.delete<Response>(`/user`);
+      // 회원 탈퇴 성공 시 refreshToken 쿠키 삭제
+      const cookie = createExpiredCookie({ name: "refreshToken" });
+      res.setHeader("Set-Cookie", cookie);
+      res.status(200).json(response.data);
+    },
+    () => {
+      delete serverApiInstance.defaults.headers.common.Authorization;
+    }
+  );
+}

--- a/src/pages/mypage/index.tsx
+++ b/src/pages/mypage/index.tsx
@@ -49,10 +49,8 @@ export default function MyPage() {
           teamId={user?.teamId || ""}
           onSuccess={async () => {
             try {
-              await clientProxyInstance.post("/api/auth/signOut");
-            } catch (error) {
-              console.error("Sign out error:", error);
-            }
+              await clientProxyInstance.post("/auth/signOut");
+            } catch {}
             logOut();
             router.replace("/login");
           }}
@@ -339,7 +337,6 @@ function SecessionAlert({
     try {
       await deleteUser({ teamId });
       onClose();
-      // 회원 탈퇴 성공 모달 표시
       overlay.open(
         ({ isOpen, close, unmount }) => (
           <Alert

--- a/src/pages/mypage/index.tsx
+++ b/src/pages/mypage/index.tsx
@@ -4,17 +4,21 @@ import { AvatarInput } from "@/components/input";
 import { Alert, ErrorAlert } from "@/components/modal";
 import InputLabel from "@/features/login/components/InputLabel";
 import PasswordVisible from "@/features/login/components/PasswordVisible";
-import { patchChangePassword } from "@/features/mypage/api";
+import { deleteUser, patchChangePassword } from "@/features/mypage/api";
+import { clientProxyInstance } from "@/services/instance/client";
 import { useAuthStore } from "@/stores/auth-store";
 import {
   validatePassword,
   validatePasswordConfirm,
 } from "@/utils/login-validator";
+import { useRouter } from "next/router";
 import { overlay } from "overlay-kit";
 import { useState } from "react";
 
 export default function MyPage() {
   const user = useAuthStore((state) => state.user);
+  const logOut = useAuthStore((state) => state.logOut);
+  const router = useRouter();
   const [name, setName] = useState(user?.nickname || "");
   const email = user?.email || "";
 
@@ -38,35 +42,20 @@ export default function MyPage() {
   const handleMembershipWithdrawalClick = () => {
     overlay.open(
       ({ isOpen, close, unmount }) => (
-        <Alert
+        <SecessionAlert
           isOpen={isOpen}
           onClose={close}
           onExit={unmount}
-          header={
-            <div className="flex h-6 w-6 items-center justify-center rounded-full bg-status-danger">
-              <Icon name="alert" size="large" color="white" />
-            </div>
-          }
-          title="회원 탈퇴를 진행하시겠어요?"
-          message="그룹장으로 있는 그룹은 자동으로 삭제되고, 모든 그룹에서 나가집니다."
-          actions={[
-            <Button
-              key="close"
-              title="닫기"
-              variant="outlinedPrimary"
-              size="large"
-              isFullWidth={true}
-              onClick={close}
-            />,
-            <Button
-              key="secession"
-              title="회원 탈퇴"
-              variant="danger"
-              size="large"
-              isFullWidth={true}
-              onClick={close}
-            />,
-          ]}
+          teamId={user?.teamId || ""}
+          onSuccess={async () => {
+            try {
+              await clientProxyInstance.post("/api/auth/signOut");
+            } catch (error) {
+              console.error("Sign out error:", error);
+            }
+            logOut();
+            router.replace("/login");
+          }}
         />
       ),
       { overlayId: "secession-alert" }
@@ -318,6 +307,112 @@ function ChangePasswordModal({
           isFullWidth={true}
           onClick={handleChangeClick}
           disabled={!isFormValid() || isLoading}
+        />,
+      ]}
+    />
+  );
+}
+
+interface SecessionAlertProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onExit: () => void;
+  teamId: string;
+  onSuccess: () => void;
+}
+
+function SecessionAlert({
+  isOpen,
+  onClose,
+  onExit,
+  teamId,
+  onSuccess,
+}: SecessionAlertProps) {
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleSecessionClick = async () => {
+    if (!teamId) {
+      return;
+    }
+
+    setIsLoading(true);
+    try {
+      await deleteUser({ teamId });
+      onClose();
+      // 회원 탈퇴 성공 모달 표시
+      overlay.open(
+        ({ isOpen, close, unmount }) => (
+          <Alert
+            isOpen={isOpen}
+            onClose={close}
+            onExit={unmount}
+            title="회원 탈퇴가 완료되었습니다"
+            actions={[
+              <Button
+                key="confirm"
+                title="확인"
+                variant="primary"
+                size="large"
+                isFullWidth={true}
+                onClick={() => {
+                  close();
+                  onSuccess();
+                }}
+              />,
+            ]}
+          />
+        ),
+        { overlayId: "secession-success-alert" }
+      );
+    } catch {
+      overlay.open(
+        ({ isOpen, close, unmount }) => (
+          <ErrorAlert
+            isOpen={isOpen}
+            onClose={close}
+            onExit={unmount}
+            title="회원 탈퇴가 실패하였습니다."
+            error={new Error("다시 시도해주세요.")}
+          />
+        ),
+        { overlayId: "secession-error-alert" }
+      );
+    } finally {
+      setIsLoading(false);
+    }
+    onClose();
+  };
+
+  return (
+    <Alert
+      isOpen={isOpen}
+      onClose={onClose}
+      onExit={onExit}
+      header={
+        <div className="flex h-6 w-6 items-center justify-center rounded-full bg-status-danger">
+          <Icon name="alert" size="large" color="white" />
+        </div>
+      }
+      title="회원 탈퇴를 진행하시겠어요?"
+      message="그룹장으로 있는 그룹은 자동으로 삭제되고, 모든 그룹에서 나가집니다."
+      actions={[
+        <Button
+          key="close"
+          title="닫기"
+          variant="outlinedPrimary"
+          size="large"
+          isFullWidth={true}
+          onClick={onClose}
+          disabled={isLoading}
+        />,
+        <Button
+          key="secession"
+          title="회원 탈퇴"
+          variant="danger"
+          size="large"
+          isFullWidth={true}
+          onClick={handleSecessionClick}
+          disabled={isLoading}
         />,
       ]}
     />


### PR DESCRIPTION
## 📝 요약
회원탈퇴 기능을 구현합니다.

## ✨ 구현 내용
- 회원가입, 로그인한 계정에서 계정설정 페이지의 회원탈퇴 버튼으로 계정을 삭제합니다.

### 🎯 실제 결과
![계정설정 페이지 - 회원탈퇴](https://github.com/user-attachments/assets/a3071fab-a23b-41b7-a81c-43ad5c956a05)


![탈퇴한 이메일로 로그인시도](https://github.com/user-attachments/assets/1b8ff7d0-1618-491c-b064-87c7a8725ae8)


### 📸 참고 자료
- chanmin@test30.com로 로그인 후 회원탈퇴
- 회원탈퇴 후 chanmin@test30.com으로 재 로그인 시도시 존재하지 않는 이메일 모달 확인

---

## 💬 리뷰어 참고 사항 및 알게된 점
- 회원탈퇴 완료 후 회원탈퇴 성공 모달 알림 다음 signOut을 호출하여 쿠키에 저장된 토큰을 삭제합니다
- 쿠키에 저장된 리프레시토큰을 정리하지 않으면 회원정보는 없는데 토큰은 남아있어서 페이지가 무한반복되는 경험을 가졌습니다

## ✅ 체크리스트
- [x] 주요 기능 테스트 완료
- [x] 빌드 및 실행 확인
- [x] 커밋 메시지 컨벤션 및 작업 내용 일치 확인