### PR TITLE
feat [#139] 계정설정 프로필 변경 구현

### DIFF
--- a/src/features/user/apis/index.ts
+++ b/src/features/user/apis/index.ts
@@ -1,3 +1,4 @@
+import { uploadImage } from "@/features/image/apis";
 import { apiRequest, APIRequestOptions } from "@/services/api-request";
 import { clientApiInstance } from "@/services/instance/client";
 import { UserGroup } from "@/types/group";
@@ -96,4 +97,31 @@ export async function patchPassword({
 
 export async function deleteUser() {
   await clientApiInstance.delete("/user");
+}
+
+interface PatchProfileParams {
+  nickname?: string;
+  imageFile?: File;
+}
+
+export async function patchProfile({
+  nickname,
+  imageFile,
+}: PatchProfileParams) {
+  const params: {
+    nickname?: string;
+    image?: string;
+  } = {};
+
+  if (nickname !== undefined && nickname.trim() !== "") {
+    params.nickname = nickname.trim();
+  }
+
+  if (imageFile) {
+    const { url } = await uploadImage({ imageFile });
+    params.image = url;
+  }
+
+  const response = await clientApiInstance.patch<User>("/user", params);
+  return response.data;
 }

--- a/src/pages/mypage/index.tsx
+++ b/src/pages/mypage/index.tsx
@@ -6,23 +6,42 @@ import { openErrorAlert } from "@/components/modal/ErrorAlert";
 import { postSignOut } from "@/features/auth/apis";
 import InputLabel from "@/features/login/components/InputLabel";
 import PasswordVisible from "@/features/login/components/PasswordVisible";
-import { deleteUser } from "@/features/user/apis";
+import { deleteUser, patchProfile } from "@/features/user/apis";
 import { useChangePasswordMutation } from "@/features/user/query";
 import { useAuthStore } from "@/stores/auth-store";
 import {
   validatePassword,
   validatePasswordConfirm,
 } from "@/utils/login-validator";
+import { isAxiosError } from "axios";
 import { useRouter } from "next/router";
 import { overlay } from "overlay-kit";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 export default function MyPage() {
   const user = useAuthStore((state) => state.user);
   const logOut = useAuthStore((state) => state.logOut);
+  const updateUser = useAuthStore((state) => state.updateUser);
   const router = useRouter();
   const [name, setName] = useState(user?.nickname || "");
+  const [profileImage, setProfileImage] = useState<File | undefined>();
+  const [previewImageUrl, setPreviewImageUrl] = useState<string | undefined>(
+    user?.image
+  );
+  const [isLoading, setIsLoading] = useState(false);
   const email = user?.email || "";
+
+  const hasChanges =
+    (name || "").trim() !== (user?.nickname || "").trim() ||
+    profileImage !== undefined;
+
+  useEffect(() => {
+    if (user) {
+      setName(user.nickname || "");
+      setProfileImage(undefined);
+      setPreviewImageUrl(user.image);
+    }
+  }, [user]);
 
   const handleChangePasswordClick = () => {
     overlay.open(
@@ -52,17 +71,117 @@ export default function MyPage() {
     );
   };
 
+  const handleAvatarChange = (file: File) => {
+    setProfileImage(file);
+    if (previewImageUrl && previewImageUrl.startsWith("blob:")) {
+      URL.revokeObjectURL(previewImageUrl);
+    }
+    const fileUrl = URL.createObjectURL(file);
+    setPreviewImageUrl(fileUrl);
+  };
+
+  useEffect(() => {
+    return () => {
+      if (previewImageUrl && previewImageUrl.startsWith("blob:")) {
+        URL.revokeObjectURL(previewImageUrl);
+      }
+    };
+  }, [previewImageUrl]);
+
+  const handleSaveClick = () => {
+    overlay.open(
+      ({ isOpen, close, unmount }) => (
+        <SaveConfirmAlert
+          isOpen={isOpen}
+          onClose={close}
+          onExit={unmount}
+          onConfirm={async () => {
+            setIsLoading(true);
+            try {
+              const response = await patchProfile({
+                nickname: name !== user?.nickname ? name : undefined,
+                imageFile: profileImage,
+              });
+
+              if (
+                profileImage &&
+                previewImageUrl &&
+                previewImageUrl.startsWith("blob:")
+              ) {
+                URL.revokeObjectURL(previewImageUrl);
+              }
+
+              if (user) {
+                const updatedUser = {
+                  ...user,
+                  ...response,
+                };
+                updateUser(updatedUser);
+              }
+
+              setProfileImage(undefined);
+              setPreviewImageUrl(response.image ?? user?.image);
+              setName(response.nickname ?? user?.nickname ?? "");
+              close();
+
+              overlay.open(
+                ({ isOpen, close, unmount }) => (
+                  <Alert
+                    isOpen={isOpen}
+                    onClose={close}
+                    onExit={unmount}
+                    title="프로필이 변경되었습니다"
+                    actions={[
+                      <Button
+                        key="confirm"
+                        title="확인"
+                        variant="primary"
+                        size="large"
+                        isFullWidth={true}
+                        onClick={close}
+                      />,
+                    ]}
+                  />
+                ),
+                { overlayId: "profile-update-success-alert" }
+              );
+            } catch (error) {
+              if (isAxiosError(error) && error.response?.status === 400) {
+                overlay.open(
+                  ({ isOpen, close, unmount }) => (
+                    <ErrorAlert
+                      isOpen={isOpen}
+                      onClose={close}
+                      onExit={unmount}
+                      title="프로필 변경이 실패하였습니다."
+                      error={new Error("다시 시도해주세요.")}
+                    />
+                  ),
+                  { overlayId: "profile-update-error-alert" }
+                );
+              } else {
+                openErrorAlert({
+                  title: "프로필 변경이 실패하였습니다.",
+                  error: new Error("다시 시도해주세요."),
+                });
+              }
+            } finally {
+              setIsLoading(false);
+            }
+          }}
+        />
+      ),
+      { overlayId: "save-confirm-alert" }
+    );
+  };
+
   return (
     <div className="flex h-screen items-center justify-center bg-background-secondary">
       <div className="flex h-195 w-230 flex-col rounded-2xl border border-border-primary bg-background-primary px-18 pt-16 pb-16">
         <h1 className="mb-10 text-2xl-b text-text-primary">계정 설정</h1>
 
         <div className="mb-9 flex justify-center">
-          <AvatarInput
-            onChange={(file) => {
-              console.log(file);
-            }}
-          />
+          <AvatarInput source={previewImageUrl} onChange={handleAvatarChange} />
         </div>
 
         <div className="flex flex-col gap-6">
@@ -103,7 +222,7 @@ export default function MyPage() {
             }
           />
 
-          <div className="mt-1 flex items-center gap-2">
+          <div className="mt-1 mr-3 flex items-center justify-between">
             <button
               className="flex h-6 w-32 cursor-pointer items-center text-left text-lg-m text-status-danger hover:text-lg-s hover:underline"
               onClick={handleMembershipWithdrawalClick}
@@ -111,6 +230,14 @@ export default function MyPage() {
               <Icon name="secession" size="large" />
               회원 탈퇴하기
             </button>
+            <Button
+              title="저장"
+              variant="primary"
+              size="small"
+              isFullWidth={false}
+              onClick={handleSaveClick}
+              disabled={!hasChanges || isLoading}
+            />
           </div>
         </div>
       </div>
@@ -294,6 +421,47 @@ function ChangePasswordModal({
           isFullWidth={true}
           onClick={handleChangeClick}
           disabled={!isFormValid() || isLoading}
+        />,
+      ]}
+    />
+  );
+}
+
+interface SaveConfirmAlertProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onExit: () => void;
+  onConfirm: () => void;
+}
+
+function SaveConfirmAlert({
+  isOpen,
+  onClose,
+  onExit,
+  onConfirm,
+}: SaveConfirmAlertProps) {
+  return (
+    <Alert
+      isOpen={isOpen}
+      onClose={onClose}
+      onExit={onExit}
+      title="변경사항을 저장하시겠습니까?"
+      actions={[
+        <Button
+          key="close"
+          title="닫기"
+          variant="outlinedPrimary"
+          size="large"
+          isFullWidth={true}
+          onClick={onClose}
+        />,
+        <Button
+          key="save"
+          title="저장하기"
+          variant="primary"
+          size="large"
+          isFullWidth={true}
+          onClick={onConfirm}
         />,
       ]}
     />

--- a/src/stores/auth-store.ts
+++ b/src/stores/auth-store.ts
@@ -11,6 +11,7 @@ interface AuthActions {
   logIn: ({ accessToken, user }: { accessToken: string; user: User }) => void;
   logOut: () => void;
   refreshToken: ({ accessToken }: { accessToken: string }) => void;
+  updateUser: (user: User) => void;
 }
 
 export const useAuthStore = create<AuthState & AuthActions>()((set) => ({
@@ -20,4 +21,5 @@ export const useAuthStore = create<AuthState & AuthActions>()((set) => ({
   logIn: ({ accessToken, user }) => set({ accessToken, user, loggedIn: true }),
   logOut: () => set({ accessToken: "", user: null, loggedIn: false }),
   refreshToken: ({ accessToken }) => set({ accessToken }),
+  updateUser: (user) => set({ user }),
 }));


### PR DESCRIPTION
## 📝 요약
 계정설정 페이지에서 프로필 변경 기능을 구현합니다

## ✨ 구현 내용
계정설정 페이지에서 이름과 프로필 페이지를 수정하면 저장 버튼이 활성화되고 활성화된 버튼을 사용해 변경사항을 저장합니다

### 🎯 실제 결과

![회원가입 - 계정설정 페이지](https://github.com/user-attachments/assets/b3a6b619-fc8b-4688-8cf7-77c8eb0df92d)

![변경사항 - 새로고침해야 변경상태 보임](https://github.com/user-attachments/assets/9d051d8c-d1ff-4bb5-9ff4-e55c3e5aa982)

### 📸 참고 자료


---

## 💬 리뷰어 참고 사항 및 알게된 점
- 이미지는 수정한 이미지가 바로 확인이 가능한데 텍스트(이름)은 변경완료 후 새로고침을 해야 변경사항이 적용된 것을 확인할 수 있습니다

## ✅ 체크리스트
- [x] 주요 기능 테스트 완료
- [x] 빌드 및 실행 확인
- [x] 커밋 메시지 컨벤션 및 작업 내용 일치 확인