### PR TITLE
[#155] 댓글 작성 유저 프로필이미지 적용 / 자유게시판 CSS 수정

### DIFF
--- a/src/features/boards/BestPost.tsx
+++ b/src/features/boards/BestPost.tsx
@@ -45,7 +45,9 @@ export default function BestPost() {
             <>
               <div className="flex gap-3 desktop:w-full desktop:max-w-[1074px]">
                 {visiblePage?.map((post) => (
-                  <PostCard key={post.id} article={post} isPopular={true} />
+                  <div key={post.id} className="min-w-0 flex-1">
+                    <PostCard article={post} isPopular={true} />
+                  </div>
                 ))}
               </div>
               <PageController

--- a/src/features/boards/PostCard.tsx
+++ b/src/features/boards/PostCard.tsx
@@ -22,9 +22,9 @@ export default function PostCard({ isPopular, article }: PostCardProps) {
     <div
       onClick={handleClick}
       className={clsx(
-        "flex w-[340px] cursor-pointer flex-col gap-3 rounded-[20px] border border-border-primary bg-background-primary tablet:h-44",
+        "flex w-full cursor-pointer flex-col gap-3 rounded-[20px] border border-border-primary bg-background-primary tablet:h-44",
         isPopular
-          ? "h-[177px] justify-between p-5 tablet:w-[304px] desktop:h-[206px] desktop:w-full desktop:max-w-[350px] desktop:px-5 desktop:py-6"
+          ? "h-[177px] justify-between p-5 tablet:max-w-none desktop:h-[206px] desktop:w-full desktop:px-5 desktop:py-6"
           : "h-[140px] justify-around p-4 tablet:h-[156px] tablet:w-[620px] tablet:px-6 tablet:py-5 desktop:w-full desktop:max-w-[529px]"
       )}
     >
@@ -37,13 +37,20 @@ export default function PostCard({ isPopular, article }: PostCardProps) {
       <div className="flex flex-col gap-2">
         <div
           className={clsx(
-            "flex h-[67px] w-[308px] justify-between tablet:h-[88px]",
+            "flex w-[308px] justify-between",
             isPopular
-              ? "tablet:w-[264px] desktop:w-full desktop:max-w-[310px]"
-              : "tablet:w-[572px] desktop:w-full desktop:max-w-[481px]"
+              ? "tablet:h-[67px] tablet:w-[264px] desktop:w-full desktop:max-w-[310px]"
+              : "tablet:h-[88px] tablet:w-[572px] desktop:w-full desktop:max-w-[481px]"
           )}
         >
-          <div className="flex flex-col gap-2">
+          <div
+            className={clsx(
+              "flex flex-col gap-2",
+              isPopular
+                ? "w-[244px] tablet:w-52 desktop:w-[242px]"
+                : "w-[228px] tablet:w-[360px]"
+            )}
+          >
             <h3 className="line-clamp-1 text-lg-b tablet:text-2lg-b">
               {title}
             </h3>
@@ -51,7 +58,7 @@ export default function PostCard({ isPopular, article }: PostCardProps) {
           {image && (
             <div
               className={clsx(
-                "relative",
+                "relative shrink-0",
                 isPopular
                   ? "h-12 w-12 desktop:h-[60px] desktop:w-[60px]"
                   : "h-20 w-20 tablet:w-[88px] desktop:h-[88px]"

--- a/src/features/boards/article/ArticleHeader.tsx
+++ b/src/features/boards/article/ArticleHeader.tsx
@@ -12,17 +12,15 @@ import { useDeleteArticleMutation } from "../hooks/mutation";
 interface ArticleHeaderProps {
   article: Article;
   currentUserId?: number;
-  userImage?: string;
 }
 
 export default function ArticleHeader({
-  userImage,
   currentUserId,
   article,
 }: ArticleHeaderProps) {
   const router = useRouter();
   const { id } = router.query;
-  const { deleteArticleMutation } = useDeleteArticleMutation(Number(id));
+  const { deleteArticleMutation } = useDeleteArticleMutation();
 
   const alertDeleteArticle = () => {
     overlay.open(
@@ -78,7 +76,7 @@ export default function ArticleHeader({
         )}
       </div>
       <div className="flex h-9 items-center gap-2">
-        <Avatar size="small" source={userImage} />
+        <Avatar size="small" />
         <div>
           <span className="text-xs-m text-text-primary tablet:text-md-m">
             {article?.writer.nickname}

--- a/src/features/comment/components/CommentPost.tsx
+++ b/src/features/comment/components/CommentPost.tsx
@@ -1,5 +1,6 @@
 import Avatar from "@/components/avatar";
 import Icon from "@/components/icon";
+import { useUserQuery } from "@/features/user/query";
 import clsx from "clsx";
 import { ChangeEvent, KeyboardEvent, useEffect, useRef, useState } from "react";
 
@@ -7,7 +8,6 @@ interface CommentPostProps {
   onSubmit?: (content: string, onSuccess?: () => void) => void;
   submitOnSuccess: boolean;
   isPending: boolean;
-  profileImage?: string;
   className?: string;
   horizontalPadding?: number;
 }
@@ -16,12 +16,13 @@ export default function CommentPost({
   onSubmit,
   submitOnSuccess,
   isPending,
-  profileImage,
   className,
   horizontalPadding,
 }: CommentPostProps) {
   const [content, setContent] = useState("");
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const { user } = useUserQuery();
+  const profileImage = user?.image;
 
   const resizeTextarea = (
     textarea: HTMLTextAreaElement | null,

--- a/src/features/comment/components/CommentSection.tsx
+++ b/src/features/comment/components/CommentSection.tsx
@@ -4,6 +4,7 @@ import { useTaskCommentMutation } from "../query/use-comment-mutation";
 import { CommentModel } from "./CommentItem";
 import CommentList from "./CommentList";
 import CommentPost from "./CommentPost";
+import { useUserQuery } from "@/features/user/query";
 
 interface CommentSectionProps {
   comments: CommentModel[];

--- a/src/pages/boards/[id].tsx
+++ b/src/pages/boards/[id].tsx
@@ -201,11 +201,7 @@ export default serverSideComponentWithAuth<PageProps>(({ articleId }) => {
         <div className="mx-auto w-[300px] pt-10 pb-10 tablet:w-[540px] tablet:pt-[54px] tablet:pb-[54px] desktop:mx-[60px] desktop:w-auto desktop:max-w-[780px]">
           {article && (
             <>
-              <ArticleHeader
-                currentUserId={userId}
-                article={article}
-                userImage={userImage}
-              />
+              <ArticleHeader currentUserId={userId} article={article} />
               <ArticleContent article={article} />
               <ArticleLikeButton
                 likeCount={article?.likeCount}

--- a/src/pages/boards/index.tsx
+++ b/src/pages/boards/index.tsx
@@ -68,7 +68,7 @@ export default function BoardsPage() {
 
   return (
     <>
-      <div className="desktop:max-w-7xl desktop:pl-24">
+      <div className="desktop:max-w-7xl desktop:pr-9 desktop:pl-24">
         <section className="border-t border-border-primary tablet:border-t-0">
           <div className="mx-auto mt-[25px] mb-5 w-[343px] tablet:mt-[77px] tablet:mb-[29px] tablet:w-[620px] desktop:mt-[87px] desktop:w-full desktop:max-w-[1120px]">
             <SearchBar value={query} onChange={setQuery} />


### PR DESCRIPTION
## 📝 요약
- 공통으로 쓰는 댓글 컴포넌트인 `CommentSection` 컴포넌트 내에서 로그인 유저의 프로필 이미지가 댓글 Input 에 보이게 설정했습니다.
- 자유게시판 진입페이지 오른쪽 여백 주었고, 창을 줄일 때 이미지는 고정을 하여 깨지듯이 보이는 현상 없앴습니다.

### 📸 참고 자료
<img width="879" height="198" alt="image" src="https://github.com/user-attachments/assets/4aaa7353-4866-46df-a35a-3dd795574046" />

<img width="1248" height="921" alt="image" src="https://github.com/user-attachments/assets/7f43e56d-392e-44fa-97c8-b906389c4f19" />

---

## 💬 리뷰어 참고 사항 및 알게된 점
리뷰어가 중점적으로 확인해야 할 부분이나, 개발 중 새로 알게 된 점이 있다면 작성해주세요.

## ✅ 체크리스트
- [x] 주요 기능 테스트 완료
- [x] 빌드 및 실행 확인
- [x] 커밋 메시지 컨벤션 및 작업 내용 일치 확인